### PR TITLE
add Validation::Message and use in Messages, MetaYmlExists

### DIFF
--- a/lib/ht_sip_validator/validation.rb
+++ b/lib/ht_sip_validator/validation.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 require "ht_sip_validator/validation/base"
 require "ht_sip_validator/validation/sip_validator"
-require 'ht_sip_validator/validation/meta_yml'
-require 'ht_sip_validator/validation/messages'
+require "ht_sip_validator/validation/meta_yml"
+require "ht_sip_validator/validation/messages"
+require "ht_sip_validator/validation/message"
 
 module HathiTrust
 

--- a/lib/ht_sip_validator/validation/base.rb
+++ b/lib/ht_sip_validator/validation/base.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "ht_sip_validator/validation/messages"
 
 module HathiTrust
   module Validation

--- a/lib/ht_sip_validator/validation/message.rb
+++ b/lib/ht_sip_validator/validation/message.rb
@@ -1,0 +1,47 @@
+module HathiTrust
+  module Validation
+
+    # Output of a validation that fails
+    class Message
+
+      ERROR = :error
+      WARNING = :warning
+
+      def initialize(validator:, validation:, level:, human_message:, extras: {})
+        @validator = validator.to_s.to_sym
+        @validation = validation.to_s.to_sym
+        @level = level
+        @human_message = human_message || "#{validator}:#{validation}"
+        @extras = extras
+      end
+
+      attr_reader :validator, :validation, :human_message
+
+      def error?
+        level == :error
+      end
+
+      def warning?
+        level == :warning
+      end
+
+      def to_s
+        "#{level.to_s.upcase}: #{validator}|#{validation} - #{human_message}"
+      end
+
+      def method_missing(message, *args)
+        if extras.has_key?(message)
+          extras[message]
+        else
+          super message, args
+        end
+      end
+
+      private
+      attr_reader :level, :extras
+
+    end
+
+  end
+end
+

--- a/lib/ht_sip_validator/validation/messages.rb
+++ b/lib/ht_sip_validator/validation/messages.rb
@@ -2,14 +2,13 @@
 module HathiTrust
   module Validation
 
-    # A collection of messages
     class Messages < Array
       def any_errors?
-        any? {|message| message[:level] == :error }
+        any? { |message| message.error? }
       end
 
-      def details
-        map {|message| message[:detail] }
+      def human_messages
+        map { |message| message.human_message }
       end
     end
 

--- a/lib/ht_sip_validator/validation/meta_yml.rb
+++ b/lib/ht_sip_validator/validation/meta_yml.rb
@@ -8,9 +8,13 @@ module HathiTrust
       class Exists < Validation::Base
         def validate
           unless @sip.files.include?("meta.yml")
-            record_message(level: :error, file: "meta.yml",
-                           type: :file_missing,
-                           detail: "SIP is missing meta.yml")
+            @messages << Message.new(
+              validator: self.class,
+              validation: :exists,
+              level: Message::ERROR,
+              human_message: 'SIP is missing meta.yml',
+              extras: {filename: 'meta.yml'}
+            )
           end
 
           super

--- a/spec/validation/message_spec.rb
+++ b/spec/validation/message_spec.rb
@@ -1,0 +1,93 @@
+require "spec_helper"
+
+module HathiTrust
+  module Validation
+
+
+
+    describe Message do
+      let(:args) {{
+        validator: "test_validator",
+        validation: "first_validation",
+        human_message: "test fail",
+        level: Message::ERROR,
+        extras: { a: 1, b: 2}
+      }}
+
+      describe "#validator" do
+        it "accepts a string" do
+          puts args
+          message = described_class.new(args.merge({validator: "val"}))
+          expect(message.validator).to eql(:val)
+        end
+        it "accepts a class" do
+          message = described_class.new(args.merge({validator: Fixnum}))
+          expect(message.validator).to eql(:Fixnum)
+        end
+        it "accepts a symbol" do
+          message = described_class.new(args.merge({validator: :some_sym}))
+          expect(message.validator).to eql(:some_sym)
+        end
+      end
+      describe "#validation" do
+        it "accepts a string" do
+          message = described_class.new(args.merge({validation: "val"}))
+          expect(message.validation).to eql(:val)
+        end
+        it "accepts a class" do
+          message = described_class.new(args.merge({validation: Fixnum}))
+          expect(message.validation).to eql(:Fixnum)
+        end
+        it "accepts a symbol" do
+          message = described_class.new(args.merge({validation: :some_sym}))
+          expect(message.validation).to eql(:some_sym)
+        end
+      end
+      describe "#human_message" do
+        it "accepts a string" do
+          message = described_class.new(args.merge({human_message: "test message"}))
+          expect(message.human_message).to eql("test message")
+        end
+      end
+      describe "#to_s" do
+        it "formats" do
+          expect(described_class.new(args).to_s)
+            .to eql("ERROR: test_validator|first_validation - test fail")
+        end
+      end
+      describe "#error?" do
+        it "is true if level == Message::ERROR" do
+          message = described_class.new(args.merge({level: Message::ERROR}))
+          expect(message.error?).to be true
+        end
+        it "is false if level == Message::WARNING" do
+          message = described_class.new(args.merge({level: Message::WARNING}))
+          expect(message.error?).to be false
+        end
+      end
+      describe "#warning?" do
+        it "is false if level == Message::ERROR" do
+          message = described_class.new(args.merge({level: Message::ERROR}))
+          expect(message.warning?).to be false
+        end
+        it "is true if level == Message::WARNING" do
+          message = described_class.new(args.merge({level: Message::WARNING}))
+          expect(message.warning?).to be true
+        end
+      end
+      describe "extras" do
+        it "keys are accessible via instance method" do
+          message = described_class.new(args.merge(extras: {a: 1, b: 2}))
+          expect(message.a).to eql(1)
+          expect(message.b).to eql(2)
+        end
+        it "throws NoMethodError if the key doesn't exist" do
+          expect{
+            described_class.new(args).zipzop
+          }.to raise_error NoMethodError
+        end
+      end
+    end
+
+  end
+end

--- a/spec/validation/messages_spec.rb
+++ b/spec/validation/messages_spec.rb
@@ -7,7 +7,7 @@ module HathiTrust
       describe "#any_errors?" do
         it "is true if there are errors" do
           msgs = described_class.new
-          msgs.push(level: :error, detail: "it is an error")
+          msgs.push Message.new(validator: :x, validation: :y, level: Message::ERROR, human_message: "z")
           expect(msgs.any_errors?).to be_truthy
         end
 

--- a/spec/validation/meta_yml_spec.rb
+++ b/spec/validation/meta_yml_spec.rb
@@ -20,7 +20,7 @@ module HathiTrust
             before(:each) { allow(mocked_sip).to receive(:files).and_return([]) }
 
             it "returns an appropriate error" do
-              expect(validator.validate.details).to include(a_string_matching(/missing meta.yml/))
+              expect(validator.validate.human_messages).to include(a_string_matching(/missing meta.yml/))
             end
           end
         end


### PR DESCRIPTION
Add a message class.  This also updates the two places it is used:  Messages and the meta yml validator.

Also moved and renamed the meta-yml validator out of the "MetaYml" namespace until such a namespace is needed.