### PR TITLE
remove explicit requires from specs and fix the errors that revealed

### DIFF
--- a/lib/ht_sip_validator/validation.rb
+++ b/lib/ht_sip_validator/validation.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 require "ht_sip_validator/validation/base"
 require "ht_sip_validator/validation/sip_validator"
+require 'ht_sip_validator/validation/meta_yml'
+require 'ht_sip_validator/validation/messages'
 
 module HathiTrust
 

--- a/spec/validation/base_spec.rb
+++ b/spec/validation/base_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require "ht_sip_validator/validation/base"
 
 module HathiTrust
   module Validation

--- a/spec/validation/messages_spec.rb
+++ b/spec/validation/messages_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require "ht_sip_validator/validation/messages"
 
 module HathiTrust
   module Validation

--- a/spec/validation/meta_yml_spec.rb
+++ b/spec/validation/meta_yml_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require "spec_helper"
-require "ht_sip_validator/validation/meta_yml"
 
 module HathiTrust
   module Validation


### PR DESCRIPTION
Using an explicit `require` of the described class in a spec hides missing `require` statements in the gem's load environment.  

I.e., `require "ht_sip_validator"` should be all someone needs to do for the gem to work, so we perform this step in the spec_helper and our tests will fail if that isn't working.