### PR TITLE
Split up concerns of Validation::SipValidator

### DIFF
--- a/lib/ht_sip_validator.rb
+++ b/lib/ht_sip_validator.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
+require "ht_sip_validator/configuration"
 require "ht_sip_validator/sip"
 require "ht_sip_validator/validation"

--- a/lib/ht_sip_validator/configuration.rb
+++ b/lib/ht_sip_validator/configuration.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require "yaml"
+
+module HathiTrust
+
+  # Represents a validation configuration.
+  class Configuration
+    attr_reader :config
+
+    def initialize(config_file_handle)
+      @config = YAML.load(config_file_handle.read) || {}
+    end
+
+    def package_checks
+      (config["package_checks"] || [])
+        .map {|name| name.sub(/\AValidation::/, "") }
+        .map {|name| HathiTrust::Validation.const_get(name) }
+    end
+  end
+
+end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+# specs for HathiTrust SIP validator service
+module HathiTrust
+
+  module Validation
+    class ConfigTestValidator; end
+  end
+
+  describe Configuration do
+    describe "#initialize" do
+      it "reads from a file handle" do
+        config = described_class.new(double(:io, read: "foo\n"))
+        expect(config.config).to eql("foo")
+      end
+
+      it "reads yaml" do
+        config = described_class.new(double(:io, read: "---\nfoo: bar\n"))
+        expect(config.config).to eql("foo" => "bar")
+      end
+    end
+
+    describe "#package_checks" do
+      it "handles an empty configuration" do
+        config = described_class.new(double(:io, read: "---\npackage_checks:\n"))
+        expect(config.package_checks).to eql([])
+      end
+
+      it "resolves a check named ConfigTestValidator" do
+        file = double(:io, read: "---\npackage_checks:\n - ConfigTestValidator\n")
+        config = described_class.new(file)
+        expect(config.package_checks).to eql([Validation::ConfigTestValidator])
+      end
+
+      it "resolves a check named ConfigTestValidator" do
+        file = double(:io, read: "---\npackage_checks:\n - Validation::ConfigTestValidator\n")
+        config = described_class.new(file)
+        expect(config.package_checks).to eql([Validation::ConfigTestValidator])
+      end
+    end
+  end
+
+end

--- a/spec/validation/sip_validator_spec.rb
+++ b/spec/validation/sip_validator_spec.rb
@@ -4,22 +4,52 @@ require "spec_helper"
 # specs for HathiTrust SIP validator service
 module HathiTrust
   module Validation
+
+    class TestValidator
+      attr_accessor :logs
+      def info(message)
+        self.logs ||= []
+        self.logs << message
+      end
+    end
+
     describe SIPValidator do
       describe "#initialize" do
-        it "accepts a path to a config.yml file" do
-          expect(described_class.new(File.new(File.join(config_path, "default.yml")))).not_to be_nil
+        it "accepts an array of validators and a logger" do
+          expect(described_class.new([double(:one)], double(:logger))).to_not be_nil
         end
       end
 
       describe "#validate" do
-        it "runs the validators in the given config" do
-          volume = SIP::SIP.new(sample_zip)
-          expect_any_instance_of(Base).to receive(:validate).and_call_original
+        let(:logger) { TestValidator.new }
 
-          validator = described_class.new("package_checks: ['Validation::Base']")
-          validator.validate(volume)
+        it "runs the validators" do
+          sip_validator = described_class.new([
+            double(:one, new: double(:one_instance, validate: [1])),
+            double(:two, new: double(:two_instance, validate: [2]))
+          ], logger)
+          expect(sip_validator.validate(double(:sip))).to eql([1, 2])
+        end
+
+        it "logs the names of validators" do
+          validators = [
+            double(:one, new: double(:one_instance, validate: [])),
+            double(:two, new: double(:two_instance, validate: []))
+          ]
+          described_class.new(validators, logger).validate(double(:sip))
+          expect(logger.logs).to eql(validators.map {|v| "Running #{v} " })
+        end
+
+        it "logs the validation errors, preserving newlines and indenting" do
+          message = double(:validation_message, to_s: "uno\ndos")
+          validation_instance = double(:validation_instance, validate: [message])
+          validation_class = double(:validation_class, new: validation_instance)
+
+          described_class.new([validation_class], logger).validate(double(:sip))
+          expect(logger.logs[1]).to eql("\tuno\n\tdos")
         end
       end
     end
+
   end
 end


### PR DESCRIPTION
The Validation::SipValidator was doing several things

1. Reading from a file via filename
2. Understanding the format of the config file
3. Discovering validator classes by name
4. Instantiating and running the validators on the sip
5. Displaying progress output
6. Displaying final formatted output via 5



This PR alters the SipValidator to perform only (4,5).  It also now returns a Message array which allows a future formatter to handle (6).  Point (5) is done via a passed instance of Logger [specifically, something that has an info(string) method], which leaves the option of passing in a NullLogger to quiet the input.

This PR also creates a Configuration class that handles (2,3).  This class expects its argument to respond to `#read`.

P.S. I really do intend to actually write a validator at some point.
