### PR TITLE
Improvements to Validation::Base

### DIFF
--- a/lib/ht_sip_validator/validation/base.rb
+++ b/lib/ht_sip_validator/validation/base.rb
@@ -5,27 +5,39 @@ module HathiTrust
 
     # Interface of validators
     class Base
+      attr_reader :sip
+
+      # @param [SIP::SIP] sip
       def initialize(sip)
         @sip = sip
-        @messages = []
       end
 
+      # Performs the validation and returns the error
+      # messages.
+      # @return [Array<Message>] Empty if no errors were
+      #   found.
       def validate
-        @messages
+        [perform_validation].flatten.reject{|i| i.nil? }
       end
 
-      protected
 
-      def record_message(params = {})
-        @messages << Message.new(params.merge(validator: self.class))
+      # Actual work of performing the validation
+      # @return [Array<Message>|Message|nil]
+      def perform_validation
+        raise NotImplementedError
       end
 
-      def record_error(params = {})
-        record_message(params.merge(level: Message::ERROR))
+
+      def create_message(params)
+        Message.new(params.merge(validator: self.class))
       end
 
-      def record_warning(params = {})
-        record_message(params.merge(level: Message::WARNING))
+      def create_error(params)
+        create_message(params.merge(level: Message::ERROR))
+      end
+
+      def create_warning(params)
+        create_message(params.merge(level: Message::WARNING))
       end
 
     end

--- a/lib/ht_sip_validator/validation/meta_yml/exists.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/exists.rb
@@ -7,16 +7,14 @@ module HathiTrust
 
       # Validates that package contains meta.yml
       class Exists < Validation::Base
-        def validate
+        def perform_validation
           unless @sip.files.include?("meta.yml")
-            record_error(
+            create_error(
               validation: :exists,
               human_message: "SIP is missing meta.yml",
               extras: { filename: "meta.yml" }
             )
           end
-
-          super
         end
       end
 

--- a/lib/ht_sip_validator/validation/meta_yml/required_keys.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/required_keys.rb
@@ -7,10 +7,10 @@ module HathiTrust
 
       class RequiredKeys < Validation::Base
         REQUIRED_KEYS = %w(capture_date)
-        def validate
-          REQUIRED_KEYS.each do |key|
+        def perform_validation
+          REQUIRED_KEYS.map do |key|
             unless @sip.meta_yml.has_key?(key)
-              record_error(
+              create_error(
                 validation: :has_field,
                 human_message: "Missing required key #{key} in meta.yml",
                 extras: { filename: "meta.yml",
@@ -19,8 +19,6 @@ module HathiTrust
 
             end
           end
-
-          super
         end
       end
 

--- a/lib/ht_sip_validator/validation/meta_yml/unknown_keys.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/unknown_keys.rb
@@ -12,17 +12,15 @@ module HathiTrust
                         image_compression_agent image_compression_tool scanning_order
                         reading_order pagedata).to_set
 
-        def validate
-          @sip.meta_yml.keys.to_set.difference(KNOWN_KEYS).each do |key|
-            record_warning(
+        def perform_validation
+          @sip.meta_yml.keys.to_set.difference(KNOWN_KEYS).map do |key|
+            create_warning(
               validation: :field_valid,
               human_message: "Unknown key #{key} in meta.yml",
               extras: { filename: "meta.yml",
                         field: key }
             )
           end
-
-          super
         end
       end
     end

--- a/lib/ht_sip_validator/validation/meta_yml/well_formed.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/well_formed.rb
@@ -7,19 +7,18 @@ module HathiTrust
 
       # Validates that meta.yml is loadable & parseable
       class WellFormed < Validation::Base
-        def validate
+        def perform_validation
           begin
             @sip.meta_yml
+            return []
           rescue RuntimeError => e
-            record_error(
+            return create_error(
               validation: :well_formed,
               human_message: "Couldn't parse meta.yml",
               extras: { filename: "meta.yml",
                 root_cause: e.message }
             )
           end
-
-          super
         end
       end
 

--- a/spec/validation/base_spec.rb
+++ b/spec/validation/base_spec.rb
@@ -4,17 +4,69 @@ require "spec_helper"
 module HathiTrust
   module Validation
     describe Base do
-      subject(:validator) { described_class.new(SIP::SIP.new("")) }
 
-      describe "#validate" do
-        it "returns an array" do
-          expect(validator.validate).to be_an_instance_of(Array)
+      class TestBaseValidator < Base
+        def initialize(validation_result)
+          super("")
+          @validtion_result = validation_result
         end
-
-        it "does not return any errors" do
-          expect(any_errors?(validator.validate)).to be_falsey
+        def perform_validation
+          @validtion_result
         end
       end
+
+
+      describe "message generation" do
+        let(:params) { {validation: "test", human_message: "sdfsdfsda" } }
+        let(:validator) { Base.new(double(:sip)) }
+        before(:each) do
+          # Override the method class to just return its arguments
+          allow(HathiTrust::Validation::Message).to receive(:new) {|args| args }
+        end
+
+        it "#create_message creates the correct message" do
+          expect(validator.create_message(params.merge({level: :test})))
+            .to eql(params.merge(level: :test, validator: validator.class))
+        end
+        it "#create_error creates the correct message" do
+          expect(validator.create_error(params))
+            .to eql params.merge(level: Message::ERROR, validator: validator.class)
+        end
+        it "#create_message creates the correct message" do
+          expect(validator.create_warning(params))
+            .to eql params.merge(level: Message::WARNING, validator: validator.class)
+        end
+      end
+
+      describe "#validate" do
+        let(:validator) { TestBaseValidator.new(validation_result)}
+        context "subclass #perform_validation returns nil" do
+          let(:validation_result) { nil }
+          it "returns an empty array" do
+            expect(validator.validate).to eql([])
+          end
+        end
+        context "subclass #perform_validation returns Message" do
+          let(:validation_result) { 1 }
+          it "returns an array of messages" do
+            expect(validator.validate).to eql([1])
+          end
+        end
+        context "subclass #perform_validation returns empty array" do
+          let(:validation_result) { [] }
+          it "returns an empty array" do
+            expect(validator.validate).to eql([])
+          end
+        end
+        context "subclass #perform_validation returns message array" do
+          let(:validation_result) { [1,2] }
+          it "returns an empty array" do
+            expect(validator.validate).to eql([1,2])
+          end
+        end
+      end
+
+
     end
   end
 end


### PR DESCRIPTION
I wanted some feedback on this before finalizing it.

This change puts more of the burden of the boilerplate work on the Base class. Instead of overriding `validate` and ensuring the interface is appeased, subclasses now just return the errors they encounter via `perform_validation`.  Accepts a message, nil, or an array of messages.

This also removes the `messages` member, making validators stateless.  As such the `record_message` family of methods are renamed to `create_message`, etc.  That said, I'm not sure about this change.  Maybe it's more convenient to just append them to an internal message thing and let Base take care of "returning" that to its #validate method (as well as clearing it between runs).