### PR TITLE
Use validation instead of validator where appropriate in specs.

### DIFF
--- a/lib/ht_sip_validator/validation/base.rb
+++ b/lib/ht_sip_validator/validation/base.rb
@@ -29,7 +29,7 @@ module HathiTrust
 
 
       def create_message(params)
-        Message.new(params.merge(validator: self.class))
+        Message.new(params.merge(validation: self.class))
       end
 
       def create_error(params)

--- a/lib/ht_sip_validator/validation/message.rb
+++ b/lib/ht_sip_validator/validation/message.rb
@@ -7,15 +7,14 @@ module HathiTrust
       ERROR = :error
       WARNING = :warning
 
-      def initialize(validator:, validation:, level:, human_message:, extras: {})
-        @validator = validator.to_s.to_sym
+      def initialize(validation:, level:, human_message:, extras: {})
         @validation = validation.to_s.to_sym
         @level = level
-        @human_message = human_message || "#{validator}:#{validation}"
+        @human_message = human_message || "#{validation}"
         @extras = extras
       end
 
-      attr_reader :validator, :validation, :human_message
+      attr_reader :validation, :human_message
 
       def error?
         level == :error
@@ -26,7 +25,7 @@ module HathiTrust
       end
 
       def to_s
-        "#{level.to_s.upcase}: #{validator}|#{validation} - #{human_message}"
+        "#{level.to_s.upcase}: #{validation} - #{human_message}"
       end
 
       def method_missing(message, *args)

--- a/spec/support/examples/a_validator_with_a_valid_package.rb
+++ b/spec/support/examples/a_validator_with_a_valid_package.rb
@@ -1,7 +1,7 @@
 
-# let(:validator) { SomeValidator.new }
-shared_examples_for "a validator with a valid package" do
+# let(:validation) { SomeValidator.new }
+shared_examples_for "a validation with a valid package" do
   it "does not return errors" do
-    expect(any_errors?(validator.validate)).to be_falsey
+    expect(any_errors?(validation.validate)).to be_falsey
   end
 end

--- a/spec/support/examples/a_validator_with_an_invalid_package.rb
+++ b/spec/support/examples/a_validator_with_an_invalid_package.rb
@@ -1,7 +1,7 @@
 
-# let(:validator) { SomeValidator.new }
-shared_examples_for "a validator with an invalid package" do
+# let(:validation) { SomeValidator.new }
+shared_examples_for "a validation with an invalid package" do
   it "returns a collection of Messages" do
-    expect(validator.validate).to all(be_an_instance_of(HathiTrust::Validation::Message))
+    expect(validation.validate).to all(be_an_instance_of(HathiTrust::Validation::Message))
   end
 end

--- a/spec/support/examples/only_warnings.rb
+++ b/spec/support/examples/only_warnings.rb
@@ -1,11 +1,11 @@
-# let(:validator) { SomeValidator.new }
 
-shared_examples_for "a validator with warnings and only warnings" do
+
+shared_examples_for "a validation with warnings and only warnings" do
   it "has at least one warning" do
-    expect(validator.validate.any?(&:warning?)).to be_truthy
+    expect(validation.validate.any?(&:warning?)).to be_truthy
   end
 
   it "has only warnings" do
-    expect(validator.validate.all?(&:warning?)).to be_truthy
+    expect(validation.validate.all?(&:warning?)).to be_truthy
   end
 end

--- a/spec/validation/base_spec.rb
+++ b/spec/validation/base_spec.rb
@@ -5,7 +5,7 @@ module HathiTrust
   module Validation
     describe Base do
 
-      class TestBaseValidator < Base
+      class TestBaseValidation < Base
         def initialize(validation_result)
           super("")
           @validtion_result = validation_result
@@ -18,50 +18,50 @@ module HathiTrust
 
       describe "message generation" do
         let(:params) { {validation: "test", human_message: "sdfsdfsda" } }
-        let(:validator) { Base.new(double(:sip)) }
+        let(:validation) { Base.new(double(:sip)) }
         before(:each) do
           # Override the method class to just return its arguments
           allow(HathiTrust::Validation::Message).to receive(:new) {|args| args }
         end
 
         it "#create_message creates the correct message" do
-          expect(validator.create_message(params.merge({level: :test})))
-            .to eql(params.merge(level: :test, validator: validator.class))
+          expect(validation.create_message(params.merge({level: :test})))
+            .to eql(params.merge(level: :test, validation: validation.class))
         end
         it "#create_error creates the correct message" do
-          expect(validator.create_error(params))
-            .to eql params.merge(level: Message::ERROR, validator: validator.class)
+          expect(validation.create_error(params))
+            .to eql params.merge(level: Message::ERROR, validation: validation.class)
         end
         it "#create_message creates the correct message" do
-          expect(validator.create_warning(params))
-            .to eql params.merge(level: Message::WARNING, validator: validator.class)
+          expect(validation.create_warning(params))
+            .to eql params.merge(level: Message::WARNING, validation: validation.class)
         end
       end
 
       describe "#validate" do
-        let(:validator) { TestBaseValidator.new(validation_result)}
+        let(:validation) { TestBaseValidation.new(validation_result)}
         context "subclass #perform_validation returns nil" do
           let(:validation_result) { nil }
           it "returns an empty array" do
-            expect(validator.validate).to eql([])
+            expect(validation.validate).to eql([])
           end
         end
         context "subclass #perform_validation returns Message" do
           let(:validation_result) { 1 }
           it "returns an array of messages" do
-            expect(validator.validate).to eql([1])
+            expect(validation.validate).to eql([1])
           end
         end
         context "subclass #perform_validation returns empty array" do
           let(:validation_result) { [] }
           it "returns an empty array" do
-            expect(validator.validate).to eql([])
+            expect(validation.validate).to eql([])
           end
         end
         context "subclass #perform_validation returns message array" do
           let(:validation_result) { [1,2] }
           it "returns an empty array" do
-            expect(validator.validate).to eql([1,2])
+            expect(validation.validate).to eql([1,2])
           end
         end
       end

--- a/spec/validation/base_spec.rb
+++ b/spec/validation/base_spec.rb
@@ -8,10 +8,10 @@ module HathiTrust
       class TestBaseValidation < Base
         def initialize(validation_result)
           super("")
-          @validtion_result = validation_result
+          @validation_result = validation_result
         end
         def perform_validation
-          @validtion_result
+          @validation_result
         end
       end
 

--- a/spec/validation/message_spec.rb
+++ b/spec/validation/message_spec.rb
@@ -7,28 +7,12 @@ module HathiTrust
 
     describe Message do
       let(:args) {{
-        validator: "test_validator",
         validation: "first_validation",
         human_message: "test fail",
         level: Message::ERROR,
         extras: { a: 1, b: 2}
       }}
 
-      describe "#validator" do
-        it "accepts a string" do
-          puts args
-          message = described_class.new(args.merge({validator: "val"}))
-          expect(message.validator).to eql(:val)
-        end
-        it "accepts a class" do
-          message = described_class.new(args.merge({validator: Fixnum}))
-          expect(message.validator).to eql(:Fixnum)
-        end
-        it "accepts a symbol" do
-          message = described_class.new(args.merge({validator: :some_sym}))
-          expect(message.validator).to eql(:some_sym)
-        end
-      end
       describe "#validation" do
         it "accepts a string" do
           message = described_class.new(args.merge({validation: "val"}))
@@ -52,7 +36,7 @@ module HathiTrust
       describe "#to_s" do
         it "formats" do
           expect(described_class.new(args).to_s)
-            .to eql("ERROR: test_validator|first_validation - test fail")
+            .to eql("ERROR: first_validation - test fail")
         end
       end
       describe "#error?" do

--- a/spec/validation/meta_yml/exists_spec.rb
+++ b/spec/validation/meta_yml/exists_spec.rb
@@ -8,21 +8,21 @@ module HathiTrust
       describe Exists do
         let(:mocked_sip) { SIP::SIP.new("") }
 
-        subject(:validator) { described_class.new(mocked_sip) }
+        subject(:validation) { described_class.new(mocked_sip) }
 
         describe "#validate" do
           context "when meta.yml exists in the package" do
             before(:each) { allow(mocked_sip).to receive(:files).and_return(["meta.yml"]) }
-            it_behaves_like "a validator with a valid package"
+            it_behaves_like "a validation with a valid package"
           end
 
           context "when meta.yml does not exist in the package" do
             before(:each) { allow(mocked_sip).to receive(:files).and_return([]) }
 
-            it_behaves_like "a validator with an invalid package"
+            it_behaves_like "a validation with an invalid package"
 
             it "returns an appropriate message" do
-              expect(human_messages(validator.validate))
+              expect(human_messages(validation.validate))
                 .to include(a_string_matching(/missing meta.yml/))
             end
           end

--- a/spec/validation/meta_yml/page_data/files_spec.rb
+++ b/spec/validation/meta_yml/page_data/files_spec.rb
@@ -11,7 +11,7 @@ module HathiTrust
           include_context "with pagedata fixtures"
 
           describe "#validate" do
-            subject(:validator) { described_class.new(mocked_sip) }
+            subject(:validation) { described_class.new(mocked_sip) }
 
             context "when all files are present for the provided pagedata" do
               before(:each) do
@@ -22,7 +22,7 @@ module HathiTrust
                   .and_return(%w(meta.yml checksum.md5 00000001.tif))
               end
 
-              it_behaves_like "a validator with a valid package"
+              it_behaves_like "a validation with a valid package"
             end
 
             context "when a file is missing that is referenced in the pagedata" do
@@ -34,10 +34,10 @@ module HathiTrust
                   .and_return(%w(meta.yml checksum.md5 00000001.tif))
               end
 
-              it_behaves_like "a validator with an invalid package"
+              it_behaves_like "a validation with an invalid package"
 
               it "returns an appropriate error message" do
-                expect(human_messages(validator.validate))
+                expect(human_messages(validation.validate))
                   .to include(a_string_matching(/.*pagedata.*00000001/))
               end
             end

--- a/spec/validation/meta_yml/page_data/keys_spec.rb
+++ b/spec/validation/meta_yml/page_data/keys_spec.rb
@@ -8,14 +8,14 @@ module HathiTrust
         describe Keys do
           describe "#validate" do
             include_context "with pagedata fixtures"
-            subject(:validator) { described_class.new(mocked_sip) }
+            subject(:validation) { described_class.new(mocked_sip) }
 
             context "when page data is a hash with filenames whose keys have label and/or orderlabel" do
               before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(good_pagedata) }
-              it_behaves_like "a validator with a valid package"
+              it_behaves_like "a validation with a valid package"
 
               it "does not return any messages" do
-                expect(validator.validate.length).to be(0)
+                expect(validation.validate.length).to be(0)
               end
             end
 
@@ -25,10 +25,10 @@ module HathiTrust
                   .and_return(pagedata_with('00000001: { label: "FRONT_COVER" }'))
               end
 
-              it_behaves_like "a validator with an invalid package"
+              it_behaves_like "a validation with an invalid package"
 
               it "returns an appropriate error message" do
-                expect(human_messages(validator.validate))
+                expect(human_messages(validation.validate))
                   .to include(a_string_matching(/filename/))
               end
             end
@@ -39,10 +39,10 @@ module HathiTrust
                   .and_return(pagedata_with('tiff_artist: "University of Michigan"'))
               end
 
-              it_behaves_like "a validator with an invalid package"
+              it_behaves_like "a validation with an invalid package"
 
               it "returns an appropriate error message" do
-                expect(human_messages(validator.validate))
+                expect(human_messages(validation.validate))
                   .to include(a_string_matching(/filename/))
               end
             end

--- a/spec/validation/meta_yml/page_data/presence_spec.rb
+++ b/spec/validation/meta_yml/page_data/presence_spec.rb
@@ -8,14 +8,14 @@ module HathiTrust
         describe Presence do
           describe "#validate" do
             include_context "with pagedata fixtures"
-            subject(:validator) { described_class.new(mocked_sip) }
+            subject(:validation) { described_class.new(mocked_sip) }
 
             context "when page data is missing" do
               before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(no_pagedata) }
-              it_behaves_like "a validator with warnings and only warnings"
+              it_behaves_like "a validation with warnings and only warnings"
 
               it "returns an appropriate message" do
-                expect(human_messages(validator.validate))
+                expect(human_messages(validation.validate))
                   .to include(a_string_matching(/page/))
               end
             end

--- a/spec/validation/meta_yml/page_data/values_spec.rb
+++ b/spec/validation/meta_yml/page_data/values_spec.rb
@@ -8,14 +8,14 @@ module HathiTrust
         describe Keys do
           describe "#validate" do
             include_context "with pagedata fixtures"
-            subject(:validator) { described_class.new(mocked_sip) }
+            subject(:validation) { described_class.new(mocked_sip) }
 
             context "when page data is a hash with filenames whose keys have label and/or orderlabel" do
               before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(good_pagedata) }
-              it_behaves_like "a validator with a valid package"
+              it_behaves_like "a validation with a valid package"
 
               it "does not return any messages" do
-                expect(validator.validate.length).to be(0)
+                expect(validation.validate.length).to be(0)
               end
             end
 
@@ -25,10 +25,10 @@ module HathiTrust
                   .and_return(pagedata_with('00000001: { label: "FRONT_COVER" }'))
               end
 
-              it_behaves_like "a validator with an invalid package"
+              it_behaves_like "a validation with an invalid package"
 
               it "returns an appropriate error message" do
-                expect(human_messages(validator.validate))
+                expect(human_messages(validation.validate))
                   .to include(a_string_matching(/filename/))
               end
             end
@@ -39,10 +39,10 @@ module HathiTrust
                   .and_return(pagedata_with('tiff_artist: "University of Michigan"'))
               end
 
-              it_behaves_like "a validator with an invalid package"
+              it_behaves_like "a validation with an invalid package"
 
               it "returns an appropriate error message" do
-                expect(human_messages(validator.validate))
+                expect(human_messages(validation.validate))
                   .to include(a_string_matching(/filename/))
               end
             end

--- a/spec/validation/meta_yml/required_keys_spec.rb
+++ b/spec/validation/meta_yml/required_keys_spec.rb
@@ -10,21 +10,21 @@ module HathiTrust
         describe "#validate" do
           include_context "with yaml fixtures"
           let(:mocked_sip) { SIP::SIP.new("") }
-          subject(:validator) { described_class.new(mocked_sip) }
+          subject(:validation) { described_class.new(mocked_sip) }
 
           context "when meta.yml has capture_date" do
             before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(valid_yaml) }
 
-            it_behaves_like "a validator with a valid package"
+            it_behaves_like "a validation with a valid package"
           end
 
           context "when meta.yml does not have capture_date" do
             before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(invalid_yaml) }
 
-            it_behaves_like "a validator with an invalid package"
+            it_behaves_like "a validation with an invalid package"
 
             it "returns an appropriate message" do
-              expect(human_messages(validator.validate))
+              expect(human_messages(validation.validate))
                 .to include(a_string_matching(/capture_date/))
             end
           end

--- a/spec/validation/meta_yml/unknown_keys_spec.rb
+++ b/spec/validation/meta_yml/unknown_keys_spec.rb
@@ -11,25 +11,25 @@ module HathiTrust
           include_context "with yaml fixtures"
 
           let(:mocked_sip) { SIP::SIP.new("") }
-          subject(:validator) { described_class.new(mocked_sip) }
+          subject(:validation) { described_class.new(mocked_sip) }
 
           context "when meta.yml has only known keys" do
             before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(valid_yaml) }
 
-            it_behaves_like "a validator with a valid package"
+            it_behaves_like "a validation with a valid package"
 
             it "does not return any messages" do
-              expect(validator.validate.length).to be(0)
+              expect(validation.validate.length).to be(0)
             end
           end
 
           context "when meta.yml has an unknown key" do
             before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(invalid_yaml) }
 
-            it_behaves_like "a validator with warnings and only warnings"
+            it_behaves_like "a validation with warnings and only warnings"
 
             it "returns an appropriate message" do
-              expect(human_messages(validator.validate))
+              expect(human_messages(validation.validate))
                 .to include(a_string_matching(/capture_elephant/))
             end
 

--- a/spec/validation/meta_yml/well_formed_spec.rb
+++ b/spec/validation/meta_yml/well_formed_spec.rb
@@ -8,24 +8,24 @@ module HathiTrust
       describe WellFormed do
         describe "#validate" do
           context "when meta.yml is well formed" do
-            subject(:validator) { described_class.new(SIP::SIP.new(sample_zip("default.zip"))) }
+            subject(:validation) { described_class.new(SIP::SIP.new(sample_zip("default.zip"))) }
 
-            it_behaves_like "a validator with a valid package"
+            it_behaves_like "a validation with a valid package"
           end
           context "when meta.yml is not well formed" do
-            subject(:validator) do
+            subject(:validation) do
               described_class.new(SIP::SIP.new(sample_zip("bad_meta_yml.zip")))
             end
 
-            it_behaves_like "a validator with an invalid package"
+            it_behaves_like "a validation with an invalid package"
 
             it "returns an appropriate message" do
-              expect(human_messages(validator.validate))
+              expect(human_messages(validation.validate))
                 .to include(a_string_matching(/Couldn't parse meta.yml/))
             end
 
             it "has underlying details of the problem" do
-              expect(validator.validate.map(&:root_cause))
+              expect(validation.validate.map(&:root_cause))
                 .to include(a_string_matching(/ tab /))
             end
           end


### PR DESCRIPTION
Some refactoring to sort out validation/validator conflation.
Additionally, removes validator as a parameter for the Message class.  Validations produce messages, but do not know about the validator that is running them (rightly so).

Closes #53