### PR TITLE
Eliminate deeply-nested modules

### DIFF
--- a/lib/ht_sip_validator/sip.rb
+++ b/lib/ht_sip_validator/sip.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
-require "ht_sip_validator/sip/checksums"
-require "ht_sip_validator/sip/sip"
-
 module HathiTrust
   # Namespace for features of the sip
   module SIP
   end
 end
+
+require "ht_sip_validator/sip/checksums"
+require "ht_sip_validator/sip/sip"
+

--- a/lib/ht_sip_validator/sip/checksums.rb
+++ b/lib/ht_sip_validator/sip/checksums.rb
@@ -1,31 +1,29 @@
 # frozen_string_literal: true
-module HathiTrust
-  module SIP
-    # Handles MD5 checksums in a checksum.md5 or similar format
-    class Checksums
-      # @return [Hash] all checksums in the given collection
-      attr_reader :checksums
+module HathiTrust::SIP
+  # Handles MD5 checksums in a checksum.md5 or similar format
+  class Checksums
+    # @return [Hash] all checksums in the given collection
+    attr_reader :checksums
 
-      # Initialize a new set of Checksums. Ignores directory names in the
-      # file names.
-      #
-      # @param checksum_file [IO] IO stream (or anything responding to
-      # #each_line) that contains a list of checksums and files
-      def initialize(checksum_file)
-        @checksums = {}
-        checksum_file.each_line do |line|
-          line.strip.match(/^([a-fA-F0-9]{32})(\s+\*?)(\S.*)/) do |m|
-            (checksum, _, filename) = m.captures
-            # Handle windows-style paths
-            filename.tr!('\\', "/")
-            @checksums[File.basename(filename).downcase] = checksum
-          end
+    # Initialize a new set of Checksums. Ignores directory names in the
+    # file names.
+    #
+    # @param checksum_file [IO] IO stream (or anything responding to
+    # #each_line) that contains a list of checksums and files
+    def initialize(checksum_file)
+      @checksums = {}
+      checksum_file.each_line do |line|
+        line.strip.match(/^([a-fA-F0-9]{32})(\s+\*?)(\S.*)/) do |m|
+          (checksum, _, filename) = m.captures
+          # Handle windows-style paths
+          filename.tr!('\\', "/")
+          @checksums[File.basename(filename).downcase] = checksum
         end
       end
+    end
 
-      def checksum_for(filename)
-        @checksums[filename]
-      end
+    def checksum_for(filename)
+      @checksums[filename]
     end
   end
 end

--- a/lib/ht_sip_validator/sip/sip.rb
+++ b/lib/ht_sip_validator/sip/sip.rb
@@ -2,72 +2,70 @@
 require "zip"
 require "yaml"
 
-module HathiTrust
-  module SIP
-    CHECKSUM_FILE = "checksum.md5"
-    META_FILE = "meta.yml"
+module HathiTrust::SIP
+  CHECKSUM_FILE = "checksum.md5"
+  META_FILE = "meta.yml"
 
-    # A HathiTrust simple SIP file, packaged as zip
-    class SIP
-      # Initialize a SubmissionPackage given an existing file
-      # @param [String] zip_file_name The path to the SIP package
-      def initialize(zip_file_name)
-        @zip_file_name = zip_file_name
-        @extraction_dir = nil
+  # A HathiTrust simple SIP file, packaged as zip
+  class SIP
+    # Initialize a SubmissionPackage given an existing file
+    # @param [String] zip_file_name The path to the SIP package
+    def initialize(zip_file_name)
+      @zip_file_name = zip_file_name
+      @extraction_dir = nil
+    end
+
+    # @return [Array] a list of file names in the SIP
+    def files
+      @files ||= open_zip do |zip_file|
+        zip_file.select {|e| !e.name_is_directory? }
+          .map(&:name)
+          .map {|e| File.basename(e) }
       end
+    end
 
-      # @return [Array] a list of file names in the SIP
-      def files
-        @files ||= open_zip do |zip_file|
-          zip_file.select {|e| !e.name_is_directory? }
-            .map(&:name)
-            .map {|e| File.basename(e) }
-        end
+    # @return [Hash] the parsed meta.yml from the SIP
+    def meta_yml
+      @meta_yml ||= file_in_zip(META_FILE) do |file|
+        YAML.load(file.read)
       end
+    end
 
-      # @return [Hash] the parsed meta.yml from the SIP
-      def meta_yml
-        @meta_yml ||= file_in_zip(META_FILE) do |file|
-          YAML.load(file.read)
-        end
+    # @return [Checksums] the checksums from checksum.md5 in the SIP
+    def checksums
+      @checksums ||= file_in_zip(CHECKSUM_FILE) do |file| 
+        Checksums.new(file)
       end
+    end
 
-      # @return [Checksums] the checksums from checksum.md5 in the SIP
-      def checksums
-        @checksums ||= file_in_zip(CHECKSUM_FILE) do |file| 
-          Checksums.new(file)
-        end
-      end
-
-      # Extracts the files to a temporary directory and passes
-      # the directory to the given block. Automatically cleans
-      # up before extract returns.
-      # @return [String] the directory files were extracted to
-      def extract
-        Dir.mktmpdir do |dir|
-          open_zip do |zip_file|
-            zip_file.each do |entry|
-              unless entry.name_is_directory?
-                entry.extract(File.join(dir, File.basename(entry.name)))
-              end
-            end
-
-            yield dir
-          end
-        end
-      end
-
-      private
-
-      def file_in_zip(file_name)
+    # Extracts the files to a temporary directory and passes
+    # the directory to the given block. Automatically cleans
+    # up before extract returns.
+    # @return [String] the directory files were extracted to
+    def extract
+      Dir.mktmpdir do |dir|
         open_zip do |zip_file|
-          yield zip_file.glob("**/#{file_name}").first.get_input_stream
+          zip_file.each do |entry|
+            unless entry.name_is_directory?
+              entry.extract(File.join(dir, File.basename(entry.name)))
+            end
+          end
+
+          yield dir
         end
       end
+    end
 
-      def open_zip(&block)
-        Zip::File.open(@zip_file_name, &block)
+    private
+
+    def file_in_zip(file_name)
+      open_zip do |zip_file|
+        yield zip_file.glob("**/#{file_name}").first.get_input_stream
       end
+    end
+
+    def open_zip(&block)
+      Zip::File.open(@zip_file_name, &block)
     end
   end
 end

--- a/lib/ht_sip_validator/validation.rb
+++ b/lib/ht_sip_validator/validation.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
-require "ht_sip_validator/validation/base"
-require "ht_sip_validator/sip_validator"
-require "ht_sip_validator/validation/meta_yml"
-require "ht_sip_validator/validation/message"
-
 module HathiTrust
 
   # Namespace for validation and validators
   module Validation
   end
 end
+
+require "ht_sip_validator/validation/base"
+require "ht_sip_validator/sip_validator"
+require "ht_sip_validator/validation/meta_yml"
+require "ht_sip_validator/validation/message"
+

--- a/lib/ht_sip_validator/validation/base.rb
+++ b/lib/ht_sip_validator/validation/base.rb
@@ -1,46 +1,44 @@
 # frozen_string_literal: true
 
-module HathiTrust
-  module Validation
+module HathiTrust::Validation
 
-    # Interface of validators
-    class Base
-      attr_reader :sip
+  # Interface of validators
+  class Base
+    attr_reader :sip
 
-      # @param [SIP::SIP] sip
-      def initialize(sip)
-        @sip = sip
-      end
+    # @param [SIP::SIP] sip
+    def initialize(sip)
+      @sip = sip
+    end
 
-      # Performs the validation and returns the error
-      # messages.
-      # @return [Array<Message>] Empty if no errors were
-      #   found.
-      def validate
-        [perform_validation].flatten.reject{|i| i.nil? }
-      end
-
-
-      # Actual work of performing the validation
-      # @return [Array<Message>|Message|nil]
-      def perform_validation
-        raise NotImplementedError
-      end
+    # Performs the validation and returns the error
+    # messages.
+    # @return [Array<Message>] Empty if no errors were
+    #   found.
+    def validate
+      [perform_validation].flatten.reject{|i| i.nil? }
+    end
 
 
-      def create_message(params)
-        Message.new(params.merge(validation: self.class))
-      end
+    # Actual work of performing the validation
+    # @return [Array<Message>|Message|nil]
+    def perform_validation
+      raise NotImplementedError
+    end
 
-      def create_error(params)
-        create_message(params.merge(level: Message::ERROR))
-      end
 
-      def create_warning(params)
-        create_message(params.merge(level: Message::WARNING))
-      end
+    def create_message(params)
+      Message.new(params.merge(validation: self.class))
+    end
 
+    def create_error(params)
+      create_message(params.merge(level: Message::ERROR))
+    end
+
+    def create_warning(params)
+      create_message(params.merge(level: Message::WARNING))
     end
 
   end
+
 end

--- a/lib/ht_sip_validator/validation/message.rb
+++ b/lib/ht_sip_validator/validation/message.rb
@@ -1,46 +1,43 @@
-module HathiTrust
-  module Validation
+module HathiTrust::Validation
 
-    # Output of a validation that fails
-    class Message
+  # Output of a validation that fails
+  class Message
 
-      ERROR = :error
-      WARNING = :warning
+    ERROR = :error
+    WARNING = :warning
 
-      def initialize(validation:, level:, human_message:, extras: {})
-        @validation = validation.to_s.to_sym
-        @level = level
-        @human_message = human_message || "#{validation}"
-        @extras = extras
-      end
-
-      attr_reader :validation, :human_message
-
-      def error?
-        level == :error
-      end
-
-      def warning?
-        level == :warning
-      end
-
-      def to_s
-        "#{level.to_s.upcase}: #{validation} - #{human_message}"
-      end
-
-      def method_missing(message, *args)
-        if extras.has_key?(message)
-          extras[message]
-        else
-          super message, args
-        end
-      end
-
-      private
-      attr_reader :level, :extras
-
+    def initialize(validation:, level:, human_message:, extras: {})
+      @validation = validation.to_s.to_sym
+      @level = level
+      @human_message = human_message || "#{validation}"
+      @extras = extras
     end
 
-  end
-end
+    attr_reader :validation, :human_message
 
+    def error?
+      level == :error
+    end
+
+    def warning?
+      level == :warning
+    end
+
+    def to_s
+      "#{level.to_s.upcase}: #{validation} - #{human_message}"
+    end
+
+    def method_missing(message, *args)
+      if extras.has_key?(message)
+        extras[message]
+      else
+        super message, args
+      end
+    end
+
+    private
+    attr_reader :level, :extras
+
+  end
+
+end

--- a/lib/ht_sip_validator/validation/meta_yml.rb
+++ b/lib/ht_sip_validator/validation/meta_yml.rb
@@ -1,13 +1,12 @@
-# frozen_string_literal: true
-require "ht_sip_validator/validation/meta_yml/exists"
-require "ht_sip_validator/validation/meta_yml/required_keys"
-require "ht_sip_validator/validation/meta_yml/well_formed"
-require "ht_sip_validator/validation/meta_yml/unknown_keys"
-require "ht_sip_validator/validation/meta_yml/pagedata"
-
 module HathiTrust
   module Validation
     module MetaYml
     end
   end
 end
+
+require "ht_sip_validator/validation/meta_yml/exists"
+require "ht_sip_validator/validation/meta_yml/required_keys"
+require "ht_sip_validator/validation/meta_yml/well_formed"
+require "ht_sip_validator/validation/meta_yml/unknown_keys"
+require "ht_sip_validator/validation/meta_yml/pagedata"

--- a/lib/ht_sip_validator/validation/meta_yml/exists.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/exists.rb
@@ -1,23 +1,17 @@
 # frozen_string_literal: true
 require "ht_sip_validator/validation/base"
 
-module HathiTrust
-  module Validation
-    module MetaYml
-
-      # Validates that package contains meta.yml
-      class Exists < Validation::Base
-        def perform_validation
-          unless @sip.files.include?("meta.yml")
-            create_error(
-              validation: :exists,
-              human_message: "SIP is missing meta.yml",
-              extras: { filename: "meta.yml" }
-            )
-          end
-        end
+module HathiTrust::Validation
+  # Validates that package contains meta.yml
+  class MetaYml::Exists < Base
+    def perform_validation
+      unless @sip.files.include?("meta.yml")
+        create_error(
+          validation: :exists,
+          human_message: "SIP is missing meta.yml",
+          extras: { filename: "meta.yml" }
+        )
       end
-
     end
   end
 end

--- a/lib/ht_sip_validator/validation/meta_yml/page_data/files.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/page_data/files.rb
@@ -2,24 +2,18 @@
 require "ht_sip_validator/validation/base"
 require "set"
 
-module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-        # Validate that each file referenced in pagedata refers to a file
-        # that's actually in the package.
-        class Files < Validation::Base
-          def perform_validation
-            @sip.meta_yml["pagedata"].keys.to_set.difference(@sip.files).map do |pagefile|
-              create_error(
-                validation: :file_present,
-                human_message: "pagedata in meta.yml references #{pagefile}, but that file "\
-                "is not in the package.",
-                extras: { filename: pagefile }
-              )
-            end
-          end
-        end
+module HathiTrust::Validation
+  # Validate that each file referenced in pagedata refers to a file
+  # that's actually in the package.
+  class MetaYml::PageData::Files < Base
+    def perform_validation
+      @sip.meta_yml["pagedata"].keys.to_set.difference(@sip.files).map do |pagefile|
+        create_error(
+          validation: :file_present,
+          human_message: "pagedata in meta.yml references #{pagefile}, but that file "\
+          "is not in the package.",
+          extras: { filename: pagefile }
+        )
       end
     end
   end

--- a/lib/ht_sip_validator/validation/meta_yml/page_data/keys.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/page_data/keys.rb
@@ -2,41 +2,33 @@
 require "ht_sip_validator/validation/base"
 require "ht_sip_validator/validation/meta_yml/page_data/files.rb"
 
-module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-
-        # Validate that the page data key in meta.yml has the expected keys & values
-        class Keys < Validation::Base
-          def perform_validation
-            @sip.meta_yml["pagedata"].keys.map do |key|
-              # special case for common error of giving a sequence rather than a filename
-              if key =~ /^\d{8}$/
-                create_error(
-                  validation: :field_valid,
-                  human_message: "The key #{key} in pagedata in meta.yml appears to refer to a "\
-                  "sequence number rather than a filename. Specify the key as #{key}.tif or "\
-                  "#{key}.jp2 (as relevant) instead.",
-                  extras: { filename: "meta.yml",
-                            field: "pagedata",
-                            actual: key }
-                )
-              elsif !key.to_s.match(/^\d{8}.(tif|jp2)$/)
-                create_error(
-                  validation: :field_valid,
-                  human_message: "The key #{key} in pagedata in meta.yml does not refer to a "\
-                  "validimage filename. Keys in the pagedata should refer to image files, "\
-                  "which must be named like 00000001.tif or .jp2",
-                  extras: { filename: "meta.yml",
-                            field: "pagedata",
-                            actual: key }
-                )
-              end
-            end
-          end
+module HathiTrust::Validation
+  # Validate that the page data key in meta.yml has the expected keys & values
+  class MetaYml::PageData::Keys < Base
+    def perform_validation
+      @sip.meta_yml["pagedata"].keys.map do |key|
+        # special case for common error of giving a sequence rather than a filename
+        if key =~ /^\d{8}$/
+          create_error(
+            validation: :field_valid,
+            human_message: "The key #{key} in pagedata in meta.yml appears to refer to a "\
+            "sequence number rather than a filename. Specify the key as #{key}.tif or "\
+            "#{key}.jp2 (as relevant) instead.",
+            extras: { filename: "meta.yml",
+                      field: "pagedata",
+                      actual: key }
+          )
+        elsif !key.to_s.match(/^\d{8}.(tif|jp2)$/)
+          create_error(
+            validation: :field_valid,
+            human_message: "The key #{key} in pagedata in meta.yml does not refer to a "\
+            "validimage filename. Keys in the pagedata should refer to image files, "\
+            "which must be named like 00000001.tif or .jp2",
+            extras: { filename: "meta.yml",
+                      field: "pagedata",
+                      actual: key }
+          )
         end
-
       end
     end
   end

--- a/lib/ht_sip_validator/validation/meta_yml/page_data/presence.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/page_data/presence.rb
@@ -2,25 +2,18 @@
 require "ht_sip_validator/validation/base"
 require "ht_sip_validator/validation/meta_yml/page_data/files.rb"
 
-module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-
-        # Validate that the page data key in meta.yml has the expected keys & values
-        class Presence < Validation::Base
-          def perform_validation
-            unless @sip.meta_yml.key?("pagedata")
-              create_warning(
-                validation: :field_presence,
-                human_message: "'pagedata' is not present in meta.yml; "\
-                "users will not have page tags or page numbers to navigate through this book.",
-                extras: { filename: "meta.yml",
-                          field: "pagedata" }
-              )
-            end
-          end
-        end
+module HathiTrust::Validation
+  # Validate that the page data key in meta.yml has the expected keys & values
+  class MetaYml::PageData::Presence < Base
+    def perform_validation
+      unless @sip.meta_yml.key?("pagedata")
+        create_warning(
+          validation: :field_presence,
+          human_message: "'pagedata' is not present in meta.yml; "\
+          "users will not have page tags or page numbers to navigate through this book.",
+          extras: { filename: "meta.yml",
+                    field: "pagedata" }
+        )
       end
     end
   end

--- a/lib/ht_sip_validator/validation/meta_yml/page_data/values.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/page_data/values.rb
@@ -2,45 +2,36 @@
 require "ht_sip_validator/validation/base"
 require "ht_sip_validator/validation/meta_yml/page_data/files.rb"
 
-module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
+module HathiTrust::Validation
+  # Validate that the page data key in meta.yml has the expected keys & values
+  class MetaYml::PageData::Values < Base
 
-        # Validate that the page data key in meta.yml has the expected keys & values
-        class Values < Validation::Base
-
-          def perform_validation
-            @sip.meta_yml["pagedata"].map do |key, value|
-              if value.is_a?(Hash)
-                value.keys
-                  .select {|k| k != "label" && k != "orderlabel" }
-                  .each do |pagedata_key| 
-                    record_bad_pagedata_value(key, pagedata_key)
-                  end
-              else
-                record_bad_pagedata_value(key, value)
-              end
+    def perform_validation
+      @sip.meta_yml["pagedata"].map do |key, value|
+        if value.is_a?(Hash)
+          value.keys
+            .select {|k| k != "label" && k != "orderlabel" }
+            .each do |pagedata_key| 
+              record_bad_pagedata_value(key, pagedata_key)
             end
-          end
-
-          private
-
-          def record_bad_pagedata_value(key, value)
-            create_error(
-              validation: :field_valid,
-              human_message: "The value #{value} for the pagedata for #{key} is not valid. "\
-              " It should be specified as { label: 'pagetag', orderlabel: 'pagenumber' }",
-              extras: { filename: "meta.yml",
-                        field: "pagedata[#{key}]",
-                        actual: value,
-                        expected: "{ label: 'pagetag', orderlabel: 'pagenumber' }" }
-            )
-          end
-
+        else
+          record_bad_pagedata_value(key, value)
         end
-
       end
+    end
+
+    private
+
+    def record_bad_pagedata_value(key, value)
+      create_error(
+        validation: :field_valid,
+        human_message: "The value #{value} for the pagedata for #{key} is not valid. "\
+        " It should be specified as { label: 'pagetag', orderlabel: 'pagenumber' }",
+        extras: { filename: "meta.yml",
+                  field: "pagedata[#{key}]",
+                  actual: value,
+                  expected: "{ label: 'pagetag', orderlabel: 'pagenumber' }" }
+      )
     end
   end
 end

--- a/lib/ht_sip_validator/validation/meta_yml/pagedata.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/pagedata.rb
@@ -1,15 +1,10 @@
 # frozen_string_literal: true
 require "ht_sip_validator/validation/base"
+
+module HathiTrust::Validation::MetaYml::PageData
+end
+
 require "ht_sip_validator/validation/meta_yml/page_data/presence"
 require "ht_sip_validator/validation/meta_yml/page_data/keys"
 require "ht_sip_validator/validation/meta_yml/page_data/values"
 require "ht_sip_validator/validation/meta_yml/page_data/files"
-
-module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-      end
-    end
-  end
-end

--- a/lib/ht_sip_validator/validation/meta_yml/required_keys.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/required_keys.rb
@@ -2,26 +2,22 @@
 require "ht_sip_validator/validation/base"
 
 module HathiTrust
-  module Validation
-    module MetaYml
 
-      class RequiredKeys < Validation::Base
-        REQUIRED_KEYS = %w(capture_date)
-        def perform_validation
-          REQUIRED_KEYS.map do |key|
-            unless @sip.meta_yml.has_key?(key)
-              create_error(
-                validation: :has_field,
-                human_message: "Missing required key #{key} in meta.yml",
-                extras: { filename: "meta.yml",
-                  field: key }
-              )
+  class Validation::MetaYml::RequiredKeys < Validation::Base
+    REQUIRED_KEYS = %w(capture_date)
+    def perform_validation
+      REQUIRED_KEYS.map do |key|
+        unless @sip.meta_yml.has_key?(key)
+          create_error(
+            validation: :has_field,
+            human_message: "Missing required key #{key} in meta.yml",
+            extras: { filename: "meta.yml",
+                      field: key }
+          )
 
-            end
-          end
         end
       end
-
     end
   end
+
 end

--- a/lib/ht_sip_validator/validation/meta_yml/unknown_keys.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/unknown_keys.rb
@@ -1,27 +1,23 @@
 # frozen_string_literal: true
 require "ht_sip_validator/validation/base"
 
-module HathiTrust
-  module Validation
-    module MetaYml
-      class UnknownKeys < Validation::Base
-        require "set"
-        KNOWN_KEYS = %w(capture_date scanner_make scanner_model scanner_user
-                        creation_date creation_agent digital_content_provider tiff_artist
-                        bitonal_resolution_dpi contone_resolution_dpi image_compression_date
-                        image_compression_agent image_compression_tool scanning_order
-                        reading_order pagedata).to_set
+module HathiTrust::Validation
+  class MetaYml::UnknownKeys < Base
+    require "set"
+    KNOWN_KEYS = %w(capture_date scanner_make scanner_model scanner_user
+                    creation_date creation_agent digital_content_provider tiff_artist
+                    bitonal_resolution_dpi contone_resolution_dpi image_compression_date
+                    image_compression_agent image_compression_tool scanning_order
+                    reading_order pagedata).to_set
 
-        def perform_validation
-          @sip.meta_yml.keys.to_set.difference(KNOWN_KEYS).map do |key|
-            create_warning(
-              validation: :field_valid,
-              human_message: "Unknown key #{key} in meta.yml",
-              extras: { filename: "meta.yml",
-                        field: key }
-            )
-          end
-        end
+    def perform_validation
+      @sip.meta_yml.keys.to_set.difference(KNOWN_KEYS).map do |key|
+        create_warning(
+          validation: :field_valid,
+          human_message: "Unknown key #{key} in meta.yml",
+          extras: { filename: "meta.yml",
+                    field: key }
+        )
       end
     end
   end

--- a/lib/ht_sip_validator/validation/meta_yml/well_formed.rb
+++ b/lib/ht_sip_validator/validation/meta_yml/well_formed.rb
@@ -1,27 +1,23 @@
 # frozen_string_literal: true
 require "ht_sip_validator/validation/base"
 
-module HathiTrust
-  module Validation
-    module MetaYml
+module HathiTrust::Validation
 
-      # Validates that meta.yml is loadable & parseable
-      class WellFormed < Validation::Base
-        def perform_validation
-          begin
-            @sip.meta_yml
-            return []
-          rescue RuntimeError => e
-            return create_error(
-              validation: :well_formed,
-              human_message: "Couldn't parse meta.yml",
-              extras: { filename: "meta.yml",
-                root_cause: e.message }
-            )
-          end
-        end
+  # Validates that meta.yml is loadable & parseable
+  class MetaYml::WellFormed < Base
+    def perform_validation
+      begin
+        @sip.meta_yml
+        return []
+      rescue RuntimeError => e
+        return create_error(
+          validation: :well_formed,
+          human_message: "Couldn't parse meta.yml",
+          extras: { filename: "meta.yml",
+            root_cause: e.message }
+        )
       end
-
     end
   end
+
 end

--- a/spec/sip/checksums_spec.rb
+++ b/spec/sip/checksums_spec.rb
@@ -2,57 +2,55 @@
 require "spec_helper"
 require "zip"
 
-module HathiTrust
-  module SIP
-    describe Checksums do
-      let(:foo_md5) { "66d3b6e55fd94f1752bc8654335d8ff4" }
-      let(:bar_md5) { "c2223b5c324e395fd9f9bb249934ac87" }
-      let(:foo_result) { { "foo" => foo_md5 } }
-      let(:bar_result) { { "bar" => bar_md5 } }
-      let(:foobar_result) { foo_result.merge(bar_result) }
+module HathiTrust::SIP
+  describe Checksums do
+    let(:foo_md5) { "66d3b6e55fd94f1752bc8654335d8ff4" }
+    let(:bar_md5) { "c2223b5c324e395fd9f9bb249934ac87" }
+    let(:foo_result) { { "foo" => foo_md5 } }
+    let(:bar_result) { { "bar" => bar_md5 } }
+    let(:foobar_result) { foo_result.merge(bar_result) }
 
-      describe "#initialize" do
-        let(:sample) { "#{foo_md5} foo\n#{bar_md5} bar\n" }
-        let(:commented_sample) { "# this is a comment\n#{sample}" }
-        let(:trailing_whitespace_sample) { "#{foo_md5} foo  " }
-        let(:path_sample) { "#{foo_md5} /home/foo/bar/some/long/path/foo" }
-        let(:windows_sample) { foo_md5 + ' *C:\Users\My Name\with\spaces \path\foo' }
-        let(:uppercase_sample) { "#{foo_md5} Foo" }
+    describe "#initialize" do
+      let(:sample) { "#{foo_md5} foo\n#{bar_md5} bar\n" }
+      let(:commented_sample) { "# this is a comment\n#{sample}" }
+      let(:trailing_whitespace_sample) { "#{foo_md5} foo  " }
+      let(:path_sample) { "#{foo_md5} /home/foo/bar/some/long/path/foo" }
+      let(:windows_sample) { foo_md5 + ' *C:\Users\My Name\with\spaces \path\foo' }
+      let(:uppercase_sample) { "#{foo_md5} Foo" }
 
-        include_context "with default zip"
-        let(:zip_stream) do
-          Zip::File.new(zip_file).glob("**/checksum.md5").first.get_input_stream
-        end
-
-        it "accepts a string" do
-          expect(described_class.new(sample).checksums).to eql(foobar_result)
-        end
-        it "ignores comments" do
-          expect(described_class.new(commented_sample).checksums).to eql(foobar_result)
-        end
-        it "ignores trailing whitespace" do
-          expect(described_class.new(trailing_whitespace_sample).checksums).to eql(foo_result)
-        end
-        it "strips paths" do
-          expect(described_class.new(path_sample).checksums).to eql(foo_result)
-        end
-        it "handles windows-style checksums" do
-          expect(described_class.new(windows_sample).checksums).to eql(foo_result)
-        end
-        it "lower-cases file names" do
-          expect(described_class.new(uppercase_sample).checksums).to eql(foo_result)
-        end
-        it "accepts an input stream from a zip file" do
-          expect(described_class.new(zip_stream).checksums).to eql(zip_checksums)
-        end
+      include_context "with default zip"
+      let(:zip_stream) do
+        Zip::File.new(zip_file).glob("**/checksum.md5").first.get_input_stream
       end
 
-      describe "#checksum_for" do
-        let(:sample) { "#{foo_md5} foo\n#{bar_md5} bar\n" }
-        let(:subject) { described_class.new(sample) }
-        it "returns the checksum for a given file" do
-          expect(subject.checksum_for("foo")).to eql(foo_md5)
-        end
+      it "accepts a string" do
+        expect(described_class.new(sample).checksums).to eql(foobar_result)
+      end
+      it "ignores comments" do
+        expect(described_class.new(commented_sample).checksums).to eql(foobar_result)
+      end
+      it "ignores trailing whitespace" do
+        expect(described_class.new(trailing_whitespace_sample).checksums).to eql(foo_result)
+      end
+      it "strips paths" do
+        expect(described_class.new(path_sample).checksums).to eql(foo_result)
+      end
+      it "handles windows-style checksums" do
+        expect(described_class.new(windows_sample).checksums).to eql(foo_result)
+      end
+      it "lower-cases file names" do
+        expect(described_class.new(uppercase_sample).checksums).to eql(foo_result)
+      end
+      it "accepts an input stream from a zip file" do
+        expect(described_class.new(zip_stream).checksums).to eql(zip_checksums)
+      end
+    end
+
+    describe "#checksum_for" do
+      let(:sample) { "#{foo_md5} foo\n#{bar_md5} bar\n" }
+      let(:subject) { described_class.new(sample) }
+      it "returns the checksum for a given file" do
+        expect(subject.checksum_for("foo")).to eql(foo_md5)
       end
     end
   end

--- a/spec/sip/sip_spec.rb
+++ b/spec/sip/sip_spec.rb
@@ -2,69 +2,67 @@
 require "spec_helper"
 
 # specs for HathiTrust submission package
-module HathiTrust
-  module SIP
-    describe SIP do
-      describe "#initialize" do
+module HathiTrust::SIP
+  describe SIP do
+    describe "#initialize" do
+      include_context "with default zip"
+      it "accepts a zip file" do
+        expect(described_class.new(zip_file)).not_to be_nil
+      end
+    end
+
+    describe "#files" do
+      include_context "with default zip"
+      it "returns a list of files inside the zip" do
+        expect(described_class.new(zip_file).files.sort).to eq(zip_files)
+      end
+    end
+
+    describe "#meta_yml" do
+      context "with a well-formed zip" do
         include_context "with default zip"
-        it "accepts a zip file" do
-          expect(described_class.new(zip_file)).not_to be_nil
+        it "parses meta.yml" do
+          expect(described_class.new(zip_file).meta_yml).to eql(zip_meta)
         end
       end
 
-      describe "#files" do
-        include_context "with default zip"
-        it "returns a list of files inside the zip" do
-          expect(described_class.new(zip_file).files.sort).to eq(zip_files)
+      context "with directory-free zip" do
+        include_context "with nodirs zip"
+        it "parses meta.yml" do
+          expect(described_class.new(zip_file).meta_yml).to eql(zip_meta)
         end
       end
 
-      describe "#meta_yml" do
-        context "with a well-formed zip" do
-          include_context "with default zip"
-          it "parses meta.yml" do
-            expect(described_class.new(zip_file).meta_yml).to eql(zip_meta)
-          end
+      context "with zip with deeply nested folder names" do
+        include_context "with deeply_nested zip"
+        it "parses meta.yml" do
+          expect(described_class.new(zip_file).meta_yml).to eql(zip_meta)
         end
+      end
+    end
 
-        context "with directory-free zip" do
-          include_context "with nodirs zip"
-          it "parses meta.yml" do
-            expect(described_class.new(zip_file).meta_yml).to eql(zip_meta)
-          end
-        end
+    describe "#checksums" do
+      include_context "with default zip"
+      it "returns a hash of filenames to checksums" do
+        expect(described_class.new(zip_file).checksums).to be_a Checksums
+      end
+    end
 
-        context "with zip with deeply nested folder names" do
-          include_context "with deeply_nested zip"
-          it "parses meta.yml" do
-            expect(described_class.new(zip_file).meta_yml).to eql(zip_meta)
+    describe "#extract" do
+      include_context "with default zip"
+      it "extracts the files to a temp directory" do
+        described_class.new(zip_file).extract do |dir|
+          zip_files.each do |file_name|
+            expect(File.exist?(File.join(dir, file_name))).to be_truthy
           end
         end
       end
 
-      describe "#checksums" do
-        include_context "with default zip"
-        it "returns a hash of filenames to checksums" do
-          expect(described_class.new(zip_file).checksums).to be_a Checksums
-        end
-      end
-
-      describe "#extract" do
-        include_context "with default zip"
-        it "extracts the files to a temp directory" do
-          described_class.new(zip_file).extract do |dir|
-            zip_files.each do |file_name|
-              expect(File.exist?(File.join(dir, file_name))).to be_truthy
-            end
-          end
-        end
-
-        it "cleans up the directory after extraction" do
-          dir_saved = nil
-          described_class.new(zip_file).extract {|dir| dir_saved = dir }
-          expect(dir_saved).not_to be_empty
-          expect(File.exist?(dir_saved)).to be_falsey
-        end
+      it "cleans up the directory after extraction" do
+        dir_saved = nil
+        described_class.new(zip_file).extract {|dir| dir_saved = dir }
+        expect(dir_saved).not_to be_empty
+        expect(File.exist?(dir_saved)).to be_falsey
       end
     end
   end

--- a/spec/validation/base_spec.rb
+++ b/spec/validation/base_spec.rb
@@ -1,72 +1,70 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-module HathiTrust
-  module Validation
-    describe Base do
+module HathiTrust::Validation
+  describe Base do
 
-      class TestBaseValidation < Base
-        def initialize(validation_result)
-          super("")
-          @validation_result = validation_result
-        end
-        def perform_validation
-          @validation_result
-        end
+    class TestBaseValidation < Base
+      def initialize(validation_result)
+        super("")
+        @validation_result = validation_result
       end
-
-
-      describe "message generation" do
-        let(:params) { {validation: "test", human_message: "sdfsdfsda" } }
-        let(:validation) { Base.new(double(:sip)) }
-        before(:each) do
-          # Override the method class to just return its arguments
-          allow(HathiTrust::Validation::Message).to receive(:new) {|args| args }
-        end
-
-        it "#create_message creates the correct message" do
-          expect(validation.create_message(params.merge({level: :test})))
-            .to eql(params.merge(level: :test, validation: validation.class))
-        end
-        it "#create_error creates the correct message" do
-          expect(validation.create_error(params))
-            .to eql params.merge(level: Message::ERROR, validation: validation.class)
-        end
-        it "#create_message creates the correct message" do
-          expect(validation.create_warning(params))
-            .to eql params.merge(level: Message::WARNING, validation: validation.class)
-        end
+      def perform_validation
+        @validation_result
       end
-
-      describe "#validate" do
-        let(:validation) { TestBaseValidation.new(validation_result)}
-        context "subclass #perform_validation returns nil" do
-          let(:validation_result) { nil }
-          it "returns an empty array" do
-            expect(validation.validate).to eql([])
-          end
-        end
-        context "subclass #perform_validation returns Message" do
-          let(:validation_result) { 1 }
-          it "returns an array of messages" do
-            expect(validation.validate).to eql([1])
-          end
-        end
-        context "subclass #perform_validation returns empty array" do
-          let(:validation_result) { [] }
-          it "returns an empty array" do
-            expect(validation.validate).to eql([])
-          end
-        end
-        context "subclass #perform_validation returns message array" do
-          let(:validation_result) { [1,2] }
-          it "returns an empty array" do
-            expect(validation.validate).to eql([1,2])
-          end
-        end
-      end
-
-
     end
+
+
+    describe "message generation" do
+      let(:params) { {validation: "test", human_message: "sdfsdfsda" } }
+      let(:validation) { Base.new(double(:sip)) }
+      before(:each) do
+        # Override the method class to just return its arguments
+        allow(HathiTrust::Validation::Message).to receive(:new) {|args| args }
+      end
+
+      it "#create_message creates the correct message" do
+        expect(validation.create_message(params.merge({level: :test})))
+          .to eql(params.merge(level: :test, validation: validation.class))
+      end
+      it "#create_error creates the correct message" do
+        expect(validation.create_error(params))
+          .to eql params.merge(level: Message::ERROR, validation: validation.class)
+      end
+      it "#create_message creates the correct message" do
+        expect(validation.create_warning(params))
+          .to eql params.merge(level: Message::WARNING, validation: validation.class)
+      end
+    end
+
+    describe "#validate" do
+      let(:validation) { TestBaseValidation.new(validation_result)}
+      context "subclass #perform_validation returns nil" do
+        let(:validation_result) { nil }
+        it "returns an empty array" do
+          expect(validation.validate).to eql([])
+        end
+      end
+      context "subclass #perform_validation returns Message" do
+        let(:validation_result) { 1 }
+        it "returns an array of messages" do
+          expect(validation.validate).to eql([1])
+        end
+      end
+      context "subclass #perform_validation returns empty array" do
+        let(:validation_result) { [] }
+        it "returns an empty array" do
+          expect(validation.validate).to eql([])
+        end
+      end
+      context "subclass #perform_validation returns message array" do
+        let(:validation_result) { [1,2] }
+        it "returns an empty array" do
+          expect(validation.validate).to eql([1,2])
+        end
+      end
+    end
+
+
   end
 end

--- a/spec/validation/message_spec.rb
+++ b/spec/validation/message_spec.rb
@@ -1,77 +1,72 @@
 require "spec_helper"
 
-module HathiTrust
-  module Validation
+module HathiTrust::Validation
+  describe Message do
+    let(:args) {{
+      validation: "first_validation",
+      human_message: "test fail",
+      level: Message::ERROR,
+      extras: { a: 1, b: 2}
+    }}
 
-
-
-    describe Message do
-      let(:args) {{
-        validation: "first_validation",
-        human_message: "test fail",
-        level: Message::ERROR,
-        extras: { a: 1, b: 2}
-      }}
-
-      describe "#validation" do
-        it "accepts a string" do
-          message = described_class.new(args.merge({validation: "val"}))
-          expect(message.validation).to eql(:val)
-        end
-        it "accepts a class" do
-          message = described_class.new(args.merge({validation: Fixnum}))
-          expect(message.validation).to eql(:Fixnum)
-        end
-        it "accepts a symbol" do
-          message = described_class.new(args.merge({validation: :some_sym}))
-          expect(message.validation).to eql(:some_sym)
-        end
+    describe "#validation" do
+      it "accepts a string" do
+        message = described_class.new(args.merge({validation: "val"}))
+        expect(message.validation).to eql(:val)
       end
-      describe "#human_message" do
-        it "accepts a string" do
-          message = described_class.new(args.merge({human_message: "test message"}))
-          expect(message.human_message).to eql("test message")
-        end
+      it "accepts a class" do
+        message = described_class.new(args.merge({validation: Fixnum}))
+        expect(message.validation).to eql(:Fixnum)
       end
-      describe "#to_s" do
-        it "formats" do
-          expect(described_class.new(args).to_s)
-            .to eql("ERROR: first_validation - test fail")
-        end
-      end
-      describe "#error?" do
-        it "is true if level == Message::ERROR" do
-          message = described_class.new(args.merge({level: Message::ERROR}))
-          expect(message.error?).to be true
-        end
-        it "is false if level == Message::WARNING" do
-          message = described_class.new(args.merge({level: Message::WARNING}))
-          expect(message.error?).to be false
-        end
-      end
-      describe "#warning?" do
-        it "is false if level == Message::ERROR" do
-          message = described_class.new(args.merge({level: Message::ERROR}))
-          expect(message.warning?).to be false
-        end
-        it "is true if level == Message::WARNING" do
-          message = described_class.new(args.merge({level: Message::WARNING}))
-          expect(message.warning?).to be true
-        end
-      end
-      describe "extras" do
-        it "keys are accessible via instance method" do
-          message = described_class.new(args.merge(extras: {a: 1, b: 2}))
-          expect(message.a).to eql(1)
-          expect(message.b).to eql(2)
-        end
-        it "throws NoMethodError if the key doesn't exist" do
-          expect{
-            described_class.new(args).zipzop
-          }.to raise_error NoMethodError
-        end
+      it "accepts a symbol" do
+        message = described_class.new(args.merge({validation: :some_sym}))
+        expect(message.validation).to eql(:some_sym)
       end
     end
-
+    describe "#human_message" do
+      it "accepts a string" do
+        message = described_class.new(args.merge({human_message: "test message"}))
+        expect(message.human_message).to eql("test message")
+      end
+    end
+    describe "#to_s" do
+      it "formats" do
+        expect(described_class.new(args).to_s)
+          .to eql("ERROR: first_validation - test fail")
+      end
+    end
+    describe "#error?" do
+      it "is true if level == Message::ERROR" do
+        message = described_class.new(args.merge({level: Message::ERROR}))
+        expect(message.error?).to be true
+      end
+      it "is false if level == Message::WARNING" do
+        message = described_class.new(args.merge({level: Message::WARNING}))
+        expect(message.error?).to be false
+      end
+    end
+    describe "#warning?" do
+      it "is false if level == Message::ERROR" do
+        message = described_class.new(args.merge({level: Message::ERROR}))
+        expect(message.warning?).to be false
+      end
+      it "is true if level == Message::WARNING" do
+        message = described_class.new(args.merge({level: Message::WARNING}))
+        expect(message.warning?).to be true
+      end
+    end
+    describe "extras" do
+      it "keys are accessible via instance method" do
+        message = described_class.new(args.merge(extras: {a: 1, b: 2}))
+        expect(message.a).to eql(1)
+        expect(message.b).to eql(2)
+      end
+      it "throws NoMethodError if the key doesn't exist" do
+        expect{
+          described_class.new(args).zipzop
+        }.to raise_error NoMethodError
+      end
+    end
   end
+
 end

--- a/spec/validation/meta_yml/exists_spec.rb
+++ b/spec/validation/meta_yml/exists_spec.rb
@@ -2,34 +2,30 @@
 require "spec_helper"
 
 module HathiTrust
-  module Validation
-    module MetaYml
 
-      describe Exists do
-        let(:mocked_sip) { SIP::SIP.new("") }
+  describe Validation::MetaYml::Exists do
+    let(:mocked_sip) { SIP::SIP.new("") }
 
-        subject(:validation) { described_class.new(mocked_sip) }
+    subject(:validation) { described_class.new(mocked_sip) }
 
-        describe "#validate" do
-          context "when meta.yml exists in the package" do
-            before(:each) { allow(mocked_sip).to receive(:files).and_return(["meta.yml"]) }
-            it_behaves_like "a validation with a valid package"
-          end
-
-          context "when meta.yml does not exist in the package" do
-            before(:each) { allow(mocked_sip).to receive(:files).and_return([]) }
-
-            it_behaves_like "a validation with an invalid package"
-
-            it "returns an appropriate message" do
-              expect(human_messages(validation.validate))
-                .to include(a_string_matching(/missing meta.yml/))
-            end
-          end
-        end
+    describe "#validate" do
+      context "when meta.yml exists in the package" do
+        before(:each) { allow(mocked_sip).to receive(:files).and_return(["meta.yml"]) }
+        it_behaves_like "a validation with a valid package"
       end
 
+      context "when meta.yml does not exist in the package" do
+        before(:each) { allow(mocked_sip).to receive(:files).and_return([]) }
 
+        it_behaves_like "a validation with an invalid package"
+
+        it "returns an appropriate message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/missing meta.yml/))
+        end
+      end
     end
   end
+
+
 end

--- a/spec/validation/meta_yml/page_data/files_spec.rb
+++ b/spec/validation/meta_yml/page_data/files_spec.rb
@@ -4,44 +4,38 @@ require "spec_helper"
 # Ensure that every file referenced in the page data refers to a file actually
 # present in the SIP
 module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-        describe Files do
-          include_context "with pagedata fixtures"
+  describe Validation::MetaYml::PageData::Files do
+    include_context "with pagedata fixtures"
 
-          describe "#validate" do
-            subject(:validation) { described_class.new(mocked_sip) }
+    describe "#validate" do
+      subject(:validation) { described_class.new(mocked_sip) }
 
-            context "when all files are present for the provided pagedata" do
-              before(:each) do
-                allow(mocked_sip).to receive(:meta_yml)
-                  .and_return(pagedata_with('00000001.tif: { label: "FRONT_COVER" }'))
+      context "when all files are present for the provided pagedata" do
+        before(:each) do
+          allow(mocked_sip).to receive(:meta_yml)
+            .and_return(pagedata_with('00000001.tif: { label: "FRONT_COVER" }'))
 
-                allow(mocked_sip).to receive(:files)
-                  .and_return(%w(meta.yml checksum.md5 00000001.tif))
-              end
+          allow(mocked_sip).to receive(:files)
+            .and_return(%w(meta.yml checksum.md5 00000001.tif))
+        end
 
-              it_behaves_like "a validation with a valid package"
-            end
+        it_behaves_like "a validation with a valid package"
+      end
 
-            context "when a file is missing that is referenced in the pagedata" do
-              before(:each) do
-                allow(mocked_sip).to receive(:meta_yml)
-                  .and_return(pagedata_with('00000001.jp2: { label: "FRONT_COVER" }'))
+      context "when a file is missing that is referenced in the pagedata" do
+        before(:each) do
+          allow(mocked_sip).to receive(:meta_yml)
+            .and_return(pagedata_with('00000001.jp2: { label: "FRONT_COVER" }'))
 
-                allow(mocked_sip).to receive(:files)
-                  .and_return(%w(meta.yml checksum.md5 00000001.tif))
-              end
+          allow(mocked_sip).to receive(:files)
+            .and_return(%w(meta.yml checksum.md5 00000001.tif))
+        end
 
-              it_behaves_like "a validation with an invalid package"
+        it_behaves_like "a validation with an invalid package"
 
-              it "returns an appropriate error message" do
-                expect(human_messages(validation.validate))
-                  .to include(a_string_matching(/.*pagedata.*00000001/))
-              end
-            end
-          end
+        it "returns an appropriate error message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/.*pagedata.*00000001/))
         end
       end
     end

--- a/spec/validation/meta_yml/page_data/keys_spec.rb
+++ b/spec/validation/meta_yml/page_data/keys_spec.rb
@@ -2,51 +2,45 @@
 require "spec_helper"
 
 module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-        describe Keys do
-          describe "#validate" do
-            include_context "with pagedata fixtures"
-            subject(:validation) { described_class.new(mocked_sip) }
+  describe Validation::MetaYml::PageData::Keys do
+    describe "#validate" do
+      include_context "with pagedata fixtures"
+      subject(:validation) { described_class.new(mocked_sip) }
 
-            context "when page data is a hash with filenames whose keys have label and/or orderlabel" do
-              before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(good_pagedata) }
-              it_behaves_like "a validation with a valid package"
+      context "when page data is a hash with filenames whose keys have label and/or orderlabel" do
+        before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(good_pagedata) }
+        it_behaves_like "a validation with a valid package"
 
-              it "does not return any messages" do
-                expect(validation.validate.length).to be(0)
-              end
-            end
+        it "does not return any messages" do
+          expect(validation.validate.length).to be(0)
+        end
+      end
 
-            context "when page data has a sequence number only" do
-              before(:each) do
-                allow(mocked_sip).to receive(:meta_yml)
-                  .and_return(pagedata_with('00000001: { label: "FRONT_COVER" }'))
-              end
+      context "when page data has a sequence number only" do
+        before(:each) do
+          allow(mocked_sip).to receive(:meta_yml)
+            .and_return(pagedata_with('00000001: { label: "FRONT_COVER" }'))
+        end
 
-              it_behaves_like "a validation with an invalid package"
+        it_behaves_like "a validation with an invalid package"
 
-              it "returns an appropriate error message" do
-                expect(human_messages(validation.validate))
-                  .to include(a_string_matching(/filename/))
-              end
-            end
+        it "returns an appropriate error message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/filename/))
+        end
+      end
 
-            context "when page data has keys from the wrong scope" do
-              before(:each) do
-                allow(mocked_sip).to receive(:meta_yml)
-                  .and_return(pagedata_with('tiff_artist: "University of Michigan"'))
-              end
+      context "when page data has keys from the wrong scope" do
+        before(:each) do
+          allow(mocked_sip).to receive(:meta_yml)
+            .and_return(pagedata_with('tiff_artist: "University of Michigan"'))
+        end
 
-              it_behaves_like "a validation with an invalid package"
+        it_behaves_like "a validation with an invalid package"
 
-              it "returns an appropriate error message" do
-                expect(human_messages(validation.validate))
-                  .to include(a_string_matching(/filename/))
-              end
-            end
-          end
+        it "returns an appropriate error message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/filename/))
         end
       end
     end

--- a/spec/validation/meta_yml/page_data/presence_spec.rb
+++ b/spec/validation/meta_yml/page_data/presence_spec.rb
@@ -2,24 +2,18 @@
 require "spec_helper"
 
 module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-        describe Presence do
-          describe "#validate" do
-            include_context "with pagedata fixtures"
-            subject(:validation) { described_class.new(mocked_sip) }
+  describe Validation::MetaYml::PageData::Presence do
+    describe "#validate" do
+      include_context "with pagedata fixtures"
+      subject(:validation) { described_class.new(mocked_sip) }
 
-            context "when page data is missing" do
-              before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(no_pagedata) }
-              it_behaves_like "a validation with warnings and only warnings"
+      context "when page data is missing" do
+        before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(no_pagedata) }
+        it_behaves_like "a validation with warnings and only warnings"
 
-              it "returns an appropriate message" do
-                expect(human_messages(validation.validate))
-                  .to include(a_string_matching(/page/))
-              end
-            end
-          end
+        it "returns an appropriate message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/page/))
         end
       end
     end

--- a/spec/validation/meta_yml/page_data/values_spec.rb
+++ b/spec/validation/meta_yml/page_data/values_spec.rb
@@ -2,51 +2,45 @@
 require "spec_helper"
 
 module HathiTrust
-  module Validation
-    module MetaYml
-      module PageData
-        describe Keys do
-          describe "#validate" do
-            include_context "with pagedata fixtures"
-            subject(:validation) { described_class.new(mocked_sip) }
+  describe Validation::MetaYml::PageData::Keys do
+    describe "#validate" do
+      include_context "with pagedata fixtures"
+      subject(:validation) { described_class.new(mocked_sip) }
 
-            context "when page data is a hash with filenames whose keys have label and/or orderlabel" do
-              before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(good_pagedata) }
-              it_behaves_like "a validation with a valid package"
+      context "when page data is a hash with filenames whose keys have label and/or orderlabel" do
+        before(:each) { allow(mocked_sip).to receive(:meta_yml).and_return(good_pagedata) }
+        it_behaves_like "a validation with a valid package"
 
-              it "does not return any messages" do
-                expect(validation.validate.length).to be(0)
-              end
-            end
+        it "does not return any messages" do
+          expect(validation.validate.length).to be(0)
+        end
+      end
 
-            context "when page data has a sequence number only" do
-              before(:each) do
-                allow(mocked_sip).to receive(:meta_yml)
-                  .and_return(pagedata_with('00000001: { label: "FRONT_COVER" }'))
-              end
+      context "when page data has a sequence number only" do
+        before(:each) do
+          allow(mocked_sip).to receive(:meta_yml)
+            .and_return(pagedata_with('00000001: { label: "FRONT_COVER" }'))
+        end
 
-              it_behaves_like "a validation with an invalid package"
+        it_behaves_like "a validation with an invalid package"
 
-              it "returns an appropriate error message" do
-                expect(human_messages(validation.validate))
-                  .to include(a_string_matching(/filename/))
-              end
-            end
+        it "returns an appropriate error message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/filename/))
+        end
+      end
 
-            context "when page data has keys from the wrong scope" do
-              before(:each) do
-                allow(mocked_sip).to receive(:meta_yml)
-                  .and_return(pagedata_with('tiff_artist: "University of Michigan"'))
-              end
+      context "when page data has keys from the wrong scope" do
+        before(:each) do
+          allow(mocked_sip).to receive(:meta_yml)
+            .and_return(pagedata_with('tiff_artist: "University of Michigan"'))
+        end
 
-              it_behaves_like "a validation with an invalid package"
+        it_behaves_like "a validation with an invalid package"
 
-              it "returns an appropriate error message" do
-                expect(human_messages(validation.validate))
-                  .to include(a_string_matching(/filename/))
-              end
-            end
-          end
+        it "returns an appropriate error message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/filename/))
         end
       end
     end

--- a/spec/validation/meta_yml/required_keys_spec.rb
+++ b/spec/validation/meta_yml/required_keys_spec.rb
@@ -2,35 +2,31 @@
 require "spec_helper"
 
 module HathiTrust
-  module Validation
-    module MetaYml
 
-      describe RequiredKeys do
+  describe Validation::MetaYml::RequiredKeys do
 
-        describe "#validate" do
-          include_context "with yaml fixtures"
-          let(:mocked_sip) { SIP::SIP.new("") }
-          subject(:validation) { described_class.new(mocked_sip) }
+    describe "#validate" do
+      include_context "with yaml fixtures"
+      let(:mocked_sip) { SIP::SIP.new("") }
+      subject(:validation) { described_class.new(mocked_sip) }
 
-          context "when meta.yml has capture_date" do
-            before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(valid_yaml) }
+      context "when meta.yml has capture_date" do
+        before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(valid_yaml) }
 
-            it_behaves_like "a validation with a valid package"
-          end
-
-          context "when meta.yml does not have capture_date" do
-            before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(invalid_yaml) }
-
-            it_behaves_like "a validation with an invalid package"
-
-            it "returns an appropriate message" do
-              expect(human_messages(validation.validate))
-                .to include(a_string_matching(/capture_date/))
-            end
-          end
-        end
+        it_behaves_like "a validation with a valid package"
       end
 
+      context "when meta.yml does not have capture_date" do
+        before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(invalid_yaml) }
+
+        it_behaves_like "a validation with an invalid package"
+
+        it "returns an appropriate message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/capture_date/))
+        end
+      end
     end
   end
+
 end

--- a/spec/validation/meta_yml/unknown_keys_spec.rb
+++ b/spec/validation/meta_yml/unknown_keys_spec.rb
@@ -2,42 +2,36 @@
 require "spec_helper"
 
 module HathiTrust
-  module Validation
-    module MetaYml
 
+  describe Validation::MetaYml::UnknownKeys do
+    describe "#validate" do
+      include_context "with yaml fixtures"
 
-      describe UnknownKeys do
-        describe "#validate" do
-          include_context "with yaml fixtures"
+      let(:mocked_sip) { SIP::SIP.new("") }
+      subject(:validation) { described_class.new(mocked_sip) }
 
-          let(:mocked_sip) { SIP::SIP.new("") }
-          subject(:validation) { described_class.new(mocked_sip) }
+      context "when meta.yml has only known keys" do
+        before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(valid_yaml) }
 
-          context "when meta.yml has only known keys" do
-            before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(valid_yaml) }
+        it_behaves_like "a validation with a valid package"
 
-            it_behaves_like "a validation with a valid package"
-
-            it "does not return any messages" do
-              expect(validation.validate.length).to be(0)
-            end
-          end
-
-          context "when meta.yml has an unknown key" do
-            before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(invalid_yaml) }
-
-            it_behaves_like "a validation with warnings and only warnings"
-
-            it "returns an appropriate message" do
-              expect(human_messages(validation.validate))
-                .to include(a_string_matching(/capture_elephant/))
-            end
-
-          end
+        it "does not return any messages" do
+          expect(validation.validate.length).to be(0)
         end
       end
 
+      context "when meta.yml has an unknown key" do
+        before(:each) { allow(mocked_sip).to receive(:meta_yml) .and_return(invalid_yaml) }
 
+        it_behaves_like "a validation with warnings and only warnings"
+
+        it "returns an appropriate message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/capture_elephant/))
+        end
+
+      end
     end
   end
+
 end

--- a/spec/validation/meta_yml/well_formed_spec.rb
+++ b/spec/validation/meta_yml/well_formed_spec.rb
@@ -2,37 +2,30 @@
 require "spec_helper"
 
 module HathiTrust
-  module Validation
-    module MetaYml
+  describe Validation::MetaYml::WellFormed do
+    describe "#validate" do
+      context "when meta.yml is well formed" do
+        subject(:validation) { described_class.new(SIP::SIP.new(sample_zip("default.zip"))) }
 
-      describe WellFormed do
-        describe "#validate" do
-          context "when meta.yml is well formed" do
-            subject(:validation) { described_class.new(SIP::SIP.new(sample_zip("default.zip"))) }
+        it_behaves_like "a validation with a valid package"
+      end
+      context "when meta.yml is not well formed" do
+        subject(:validation) do
+          described_class.new(SIP::SIP.new(sample_zip("bad_meta_yml.zip")))
+        end
 
-            it_behaves_like "a validation with a valid package"
-          end
-          context "when meta.yml is not well formed" do
-            subject(:validation) do
-              described_class.new(SIP::SIP.new(sample_zip("bad_meta_yml.zip")))
-            end
+        it_behaves_like "a validation with an invalid package"
 
-            it_behaves_like "a validation with an invalid package"
+        it "returns an appropriate message" do
+          expect(human_messages(validation.validate))
+            .to include(a_string_matching(/Couldn't parse meta.yml/))
+        end
 
-            it "returns an appropriate message" do
-              expect(human_messages(validation.validate))
-                .to include(a_string_matching(/Couldn't parse meta.yml/))
-            end
-
-            it "has underlying details of the problem" do
-              expect(validation.validate.map(&:root_cause))
-                .to include(a_string_matching(/ tab /))
-            end
-          end
+        it "has underlying details of the problem" do
+          expect(validation.validate.map(&:root_cause))
+            .to include(a_string_matching(/ tab /))
         end
       end
-
-
     end
   end
 end


### PR DESCRIPTION
This eliminates most module nesting by:

- making sure nested modules are defined in only one place -- this does have the disadvantage that files can't be required piecemeal, but if we ever have a need to do that there are certainly other ways to organize the includes to make that work cleanly.

- in class definitions as well as specs, opening modules at the appopriate level to minimize verbosity in class instantiation and description, for example
```ruby
module A::B
  class C::D < BaseClass
    ...
  end
end

module A
  describe B::C::D
    ...
  end
end
```
