### PR TITLE
Add :validator field to Validation::Message.

### DIFF
--- a/lib/ht_sip_validator/validation/base.rb
+++ b/lib/ht_sip_validator/validation/base.rb
@@ -26,7 +26,7 @@ module HathiTrust::Validation
     end
 
     def create_message(params)
-      Message.new(params.merge(validation: self.class))
+      Message.new(params.merge(validator: self.class.to_s.split("Validation::").last))
     end
 
     def create_error(params)

--- a/lib/ht_sip_validator/validation/message.rb
+++ b/lib/ht_sip_validator/validation/message.rb
@@ -7,14 +7,15 @@ module HathiTrust::Validation
     ERROR = :error
     WARNING = :warning
 
-    def initialize(validation:, level:, human_message:, extras: {})
+    def initialize(validator:, validation:, level:, human_message:, extras: {})
+      @validator = validator.to_s.to_sym
       @validation = validation.to_s.to_sym
       @level = level
       @human_message = human_message || validation.to_s
       @extras = extras
     end
 
-    attr_reader :validation, :human_message
+    attr_reader :validator, :validation, :human_message
 
     def error?
       level == :error
@@ -25,7 +26,7 @@ module HathiTrust::Validation
     end
 
     def to_s
-      "#{level.to_s.upcase}: #{validation} - #{human_message}"
+      "#{level.to_s.upcase}: #{validator}|#{validation} - #{human_message}"
     end
 
     def method_missing(message, *args)
@@ -40,8 +41,16 @@ module HathiTrust::Validation
       extras.key?(message) || super
     end
 
-    private
+    def ==(other)
+      other.is_a?(self.class) &&
+        validator == other.validator &&
+        validation == other.validation &&
+        level == other.level &&
+        human_message == other.human_message &&
+        extras == other.extras
+    end
 
+    private
     attr_reader :level, :extras
 
   end

--- a/spec/validation/base_spec.rb
+++ b/spec/validation/base_spec.rb
@@ -16,7 +16,7 @@ module HathiTrust::Validation
 
     describe "message generation" do
       let(:params) { { validation: "test", human_message: "sdfsdfsda" } }
-      let(:validation) { Base.new(double(:sip)) }
+      let(:validation) { TestBaseValidation.new(double(:sip)) }
       before(:each) do
         # Override the method class to just return its arguments
         allow(HathiTrust::Validation::Message).to receive(:new) {|args| args }
@@ -24,15 +24,15 @@ module HathiTrust::Validation
 
       it "#create_message creates the correct message" do
         expect(validation.create_message(params.merge(level: :test)))
-          .to eql(params.merge(level: :test, validation: validation.class))
+          .to eql(params.merge(level: :test, validator: "TestBaseValidation", validation: "test"))
       end
       it "#create_error creates the correct message" do
         expect(validation.create_error(params))
-          .to eql params.merge(level: Message::ERROR, validation: validation.class)
+          .to eql params.merge(level: Message::ERROR, validator: "TestBaseValidation", validation: "test")
       end
       it "#create_message creates the correct message" do
         expect(validation.create_warning(params))
-          .to eql params.merge(level: Message::WARNING, validation: validation.class)
+          .to eql params.merge(level: Message::WARNING, validator: "TestBaseValidation", validation: "test")
       end
     end
 

--- a/spec/validation/message_spec.rb
+++ b/spec/validation/message_spec.rb
@@ -5,6 +5,7 @@ module HathiTrust::Validation
   describe Message do
     let(:args) do
       {
+        validator: "MyTest::Validator",
         validation: "first_validation",
         human_message: "test fail",
         level: Message::ERROR,
@@ -35,7 +36,7 @@ module HathiTrust::Validation
     describe "#to_s" do
       it "formats" do
         expect(described_class.new(args).to_s)
-          .to eql("ERROR: first_validation - test fail")
+          .to eql("ERROR: MyTest::Validator|first_validation - test fail")
       end
     end
     describe "#error?" do


### PR DESCRIPTION
Thus a message now has `validator` and a `validation`.  The former should always be the stringified name of the class, while the validation itself is whatever makes sense.  For the MetaYml:DateFormat validator, we'd thus have two messages that could be generated:

```
validator: "MetaYml::DateFormat", validation: :capture_date
validator: "MetaYml::DateFormat", validation: :image_comprssion_date
```
