### PR TITLE
Feature/issue 5: dependencies for validators

### DIFF
--- a/lib/ht_sip_validator/configuration.rb
+++ b/lib/ht_sip_validator/configuration.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require "yaml"
+require "ht_sip_validator/validator_config"
 
 module HathiTrust # rubocop:disable Style/ClassAndModuleChildren
 
@@ -13,8 +14,7 @@ module HathiTrust # rubocop:disable Style/ClassAndModuleChildren
 
     def package_checks
       (config["package_checks"] || [])
-        .map {|name| name.sub(/\AValidator::/, "") }
-        .map {|name| Validator.const_get(name) }
+        .map {|config| ValidatorConfig.new(config) }
     end
   end
 

--- a/lib/ht_sip_validator/sip_validator_runner.rb
+++ b/lib/ht_sip_validator/sip_validator_runner.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
+require "ht_sip_validator/validator_config"
+
 # Service reponsible for running a set of Validators on a sip
 class HathiTrust::SIPValidatorRunner
   # Creates a new validator service using the specified configuration
-  def initialize(validators, logger)
-    @validators = validators
+  def initialize(configuration, logger)
+    @validators = configuration
     @logger = logger
   end
 
@@ -11,11 +13,67 @@ class HathiTrust::SIPValidatorRunner
   #
   # @param sip [SubmissionPackage] The volume to validate
   def run_validators_on(sip)
-    messages = @validators.map do |validator_class|
-      @logger.info "Running #{validator_class} "
-      errors = validator_class.new(sip).validate
-      errors.each {|error| @logger.info "\t" + error.to_s.gsub("\n", "\n\t") }
+    results = {}
+    messages = @validators.map do |validator_config|
+      if prereqs_succeeded(validator_config.prerequisites, results)
+        run_validator_on(validator_config.validator_class, sip, results)
+      else
+        skip_validator(validator_config, results)
+      end
     end
     messages.reduce(:+)
   end
+
+  private
+
+  def prereqs_succeeded(prerequisites, results)
+    prerequisites.all? {|p| results[p] == true }
+  end
+
+  def failed_prereqs(prerequisites, results)
+    prerequisites.select {|p| results[p] != true }
+  end
+
+  def run_validator_on(validator_class, sip, results)
+    @logger.info "Running #{validator_class} "
+
+    errors = validator_class.new(sip).validate
+    results[validator_class] = validator_success?(errors)
+    errors.each {|error| @logger.info "\t" + error.to_s.gsub("\n", "\n\t") }
+  end
+
+  def skip_validator(validator_config, results)
+    # if prerequisites didn't run
+    results[validator_config.validator_class] = :skipped
+
+    message = "Skipping #{validator_config.validator_class}: " +
+      failed_prereqs(validator_config.prerequisites, results).map do |p|
+        p.to_s + " " + prereq_failure_message(results[p])
+      end.join("; ")
+
+    @logger.send(message_error_level(validator_config, results), message)
+  end
+
+  def message_error_level(validator_config, results)
+    if validator_config.prerequisites.any? {|p| !results.key?(p) }
+      :error
+    else
+      :info
+    end
+  end
+
+  def prereq_failure_message(result)
+    if result == :skipped
+      "was skipped"
+    elsif result == false
+      "failed"
+    elsif result.nil?
+      "must be run before this validator"
+    end
+  end
+
+  def validator_success?(messages)
+    !messages.any?(&:error?)
+  end
+
 end

--- a/lib/ht_sip_validator/validator_config.rb
+++ b/lib/ht_sip_validator/validator_config.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module HathiTrust # rubocop:disable Style/ClassAndModuleChildren
+  # Representation of configuration for a single Validator
+  class ValidatorConfig
+    attr_reader :prerequisites
+    attr_reader :validator_class
+
+    def initialize(validator_config)
+      @prerequisites = parse_prerequisites(validator_config).map do |prereq|
+        Validator.const_get(prereq)
+      end
+
+      @validator_class = Validator.const_get(parse_validator_class(validator_config))
+    end
+
+    private
+
+    def no_prereqs?(validator_config)
+      validator_config.is_a?(String)
+    end
+
+    def one_prerequisite?(validator_config)
+      validator_config.is_a?(Hash) && (validator_config.size == 1) &&
+        validator_config.values.first.is_a?(String)
+    end
+
+    def multi_prerequisites?(validator_config)
+      validator_config.is_a?(Hash) && (validator_config.size == 1) &&
+        validator_config.values.first.is_a?(Array) &&
+        validator_config.values.first.all? {|v| v.is_a?(String) }
+    end
+
+    def parse_prerequisites(validator_config)
+      if no_prereqs?(validator_config)
+        []
+      elsif one_prerequisite?(validator_config)
+        [validator_config.values.first]
+      elsif multi_prerequisites?(validator_config)
+        validator_config.values.first
+      else
+        bad_validator_config(validator_config)
+      end
+    end
+
+    def parse_validator_class(validator_config)
+      if no_prereqs?(validator_config)
+        validator_config
+      elsif one_prerequisite?(validator_config) ||
+          multi_prerequisites?(validator_config)
+        validator_config.keys.first
+      else
+        bad_validator_config(validator_config)
+      end
+    end
+
+    def bad_validator_config(validator_config)
+      raise ArgumentError, "bad validator specification #{validator_config}:"\
+        " should be like 'Validator', 'Validator: PrerequisiteValidator',"\
+        " or 'Validator: [PrereqOne, PrereqTwo, ...]"
+    end
+  end
+end

--- a/lib/ht_sip_validator/validator_config.rb
+++ b/lib/ht_sip_validator/validator_config.rb
@@ -7,57 +7,26 @@ module HathiTrust # rubocop:disable Style/ClassAndModuleChildren
     attr_reader :validator_class
 
     def initialize(validator_config)
-      @prerequisites = parse_prerequisites(validator_config).map do |prereq|
+      bad_validator_config(validator_config) unless valid_configuration(validator_config)
+
+      @prerequisites = validator_config.values.first.map do |prereq|
         Validator.const_get(prereq)
       end
 
-      @validator_class = Validator.const_get(parse_validator_class(validator_config))
+      @validator_class = Validator.const_get(validator_config.keys.first)
     end
 
     private
 
-    def no_prereqs?(validator_config)
-      validator_config.is_a?(String)
-    end
-
-    def one_prerequisite?(validator_config)
-      validator_config.is_a?(Hash) && (validator_config.size == 1) &&
-        validator_config.values.first.is_a?(String)
-    end
-
-    def multi_prerequisites?(validator_config)
+    def valid_configuration(validator_config)
       validator_config.is_a?(Hash) && (validator_config.size == 1) &&
         validator_config.values.first.is_a?(Array) &&
         validator_config.values.first.all? {|v| v.is_a?(String) }
     end
 
-    def parse_prerequisites(validator_config)
-      if no_prereqs?(validator_config)
-        []
-      elsif one_prerequisite?(validator_config)
-        [validator_config.values.first]
-      elsif multi_prerequisites?(validator_config)
-        validator_config.values.first
-      else
-        bad_validator_config(validator_config)
-      end
-    end
-
-    def parse_validator_class(validator_config)
-      if no_prereqs?(validator_config)
-        validator_config
-      elsif one_prerequisite?(validator_config) ||
-          multi_prerequisites?(validator_config)
-        validator_config.keys.first
-      else
-        bad_validator_config(validator_config)
-      end
-    end
-
     def bad_validator_config(validator_config)
       raise ArgumentError, "bad validator specification #{validator_config}:"\
-        " should be like 'Validator', 'Validator: PrerequisiteValidator',"\
-        " or 'Validator: [PrereqOne, PrereqTwo, ...]"
+        " should be like 'Validator: [PrerequisiteOne, PrerequisiteTwo, ...]"
     end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -26,7 +26,7 @@ module HathiTrust
       end
 
       it "resolves a check named ConfigTestValidator" do
-        file = double(:io, read: "---\npackage_checks:\n - ConfigTestValidator\n")
+        file = double(:io, read: "---\npackage_checks:\n - ConfigTestValidator: []\n")
         config = described_class.new(file)
         expect(config.package_checks.map(&:validator_class))
           .to eql([Validator::ConfigTestValidator])

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -28,13 +28,8 @@ module HathiTrust
       it "resolves a check named ConfigTestValidator" do
         file = double(:io, read: "---\npackage_checks:\n - ConfigTestValidator\n")
         config = described_class.new(file)
-        expect(config.package_checks).to eql([Validator::ConfigTestValidator])
-      end
-
-      it "resolves a check named ConfigTestValidator" do
-        file = double(:io, read: "---\npackage_checks:\n - Validator::ConfigTestValidator\n")
-        config = described_class.new(file)
-        expect(config.package_checks).to eql([Validator::ConfigTestValidator])
+        expect(config.package_checks.map(&:validator_class))
+          .to eql([Validator::ConfigTestValidator])
       end
     end
   end

--- a/spec/fixtures/config/minimal_config.yml
+++ b/spec/fixtures/config/minimal_config.yml
@@ -1,3 +1,3 @@
 ---
 package_checks:
- - Validator::MetaYml::Exists
+ - MetaYml::Exists

--- a/spec/fixtures/config/minimal_config.yml
+++ b/spec/fixtures/config/minimal_config.yml
@@ -1,3 +1,3 @@
 ---
 package_checks:
- - MetaYml::Exists
+  - MetaYml::Exists: []

--- a/spec/support/contexts/with_stubbed_validators.rb
+++ b/spec/support/contexts/with_stubbed_validators.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+shared_context "with stubbed validators" do
+  let(:message) { double("a validator message", to_s: "uno\ndos", error?: false) }
+  let(:validator_instance)  { double("a validator", validate: [message]) }
+
+  before(:each) do
+    %w(ValidatorOne ValidatorTwo ValidatorThree).each do |validator|
+      class_double("HathiTrust::Validator::#{validator}",
+        new: validator_instance).as_stubbed_const
+    end
+  end
+end

--- a/spec/support/contexts/with_test_logger.rb
+++ b/spec/support/contexts/with_test_logger.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+shared_context "with test logger" do
+  # Stand in class for the Logger
+  class TestLogger
+    attr_accessor :logs, :level
+    def info(message)
+      self.logs ||= []
+      self.logs << message
+    end
+
+    def error(message)
+      info(message)
+    end
+  end
+end

--- a/spec/validate_sip_command_spec.rb
+++ b/spec/validate_sip_command_spec.rb
@@ -4,14 +4,7 @@ require "spec_helper"
 module HathiTrust
 
   describe ValidateSIPCommand, integration: true do
-    class TestLogger
-      attr_accessor :logs, :level
-      def info(message)
-        self.logs ||= []
-        self.logs << message
-      end
-    end
-
+    include_context "with test logger"
     include_context "with default zip"
     include_context "with minimal config"
     let(:logger) { TestLogger.new }

--- a/spec/validation/sip_validator_spec.rb
+++ b/spec/validation/sip_validator_spec.rb
@@ -7,7 +7,7 @@ module HathiTrust
 
     describe "#initialize" do
       it "accepts an array of validator configurations and a logger" do
-        validator_config = ValidatorConfig.new("ValidatorOne")
+        validator_config = ValidatorConfig.new("ValidatorOne": [])
         logger = double("a logger")
         expect(described_class.new([validator_config], logger)).to_not be_nil
       end
@@ -18,8 +18,8 @@ module HathiTrust
       let(:sip)     { double("a sip") }
       let(:logger)  { TestLogger.new }
       let(:config) do
-        [ValidatorConfig.new("ValidatorOne"),
-         ValidatorConfig.new("ValidatorTwo")]
+        [ValidatorConfig.new("ValidatorOne": []),
+         ValidatorConfig.new("ValidatorTwo": [])]
       end
       let(:validator) { described_class.new(config, logger) }
 
@@ -62,8 +62,8 @@ module HathiTrust
 
         context "when a validator with a dependency fails" do
           let(:error_config) do
-            [ValidatorConfig.new("AlwaysError"),
-             ValidatorConfig.new("ValidatorOne": "AlwaysError")]
+            [ValidatorConfig.new("AlwaysError": []),
+             ValidatorConfig.new("ValidatorOne": ["AlwaysError"])]
           end
           let(:error_validator) { described_class.new(error_config, logger) }
 
@@ -82,7 +82,7 @@ module HathiTrust
         end
 
         it "reports appropriately if dependency hasn't been run yet" do
-          error_config = [ValidatorConfig.new("ValidatorOne": "AlwaysError")]
+          error_config = [ValidatorConfig.new("ValidatorOne": ["AlwaysError"])]
           error_validator = described_class.new(error_config, logger)
 
           error_validator.run_validators_on(sip)
@@ -92,9 +92,9 @@ module HathiTrust
         end
 
         it "reports if depdendency was skipped" do
-          error_config = [ValidatorConfig.new("AlwaysError"),
-                          ValidatorConfig.new("ValidatorOne": "AlwaysError"),
-                          ValidatorConfig.new("ValidatorTwo": "ValidatorOne")]
+          error_config = [ValidatorConfig.new("AlwaysError": []),
+                          ValidatorConfig.new("ValidatorOne": ["AlwaysError"]),
+                          ValidatorConfig.new("ValidatorTwo": ["ValidatorOne"])]
           error_validator = described_class.new(error_config, logger)
 
           error_validator.run_validators_on(sip)

--- a/spec/validation/sip_validator_spec.rb
+++ b/spec/validation/sip_validator_spec.rb
@@ -1,53 +1,108 @@
 # frozen_string_literal: true
 require "spec_helper"
 
-# Stand in class for the Logger
-class TestLogger
-  attr_accessor :logs
-  def info(message)
-    self.logs ||= []
-    self.logs << message
-  end
-end
+module HathiTrust
+  describe SIPValidatorRunner do
+    include_context "with stubbed validators"
 
-describe HathiTrust::SIPValidatorRunner do
-  describe "#initialize" do
-    it "accepts an array of validator classes and a logger" do
-      validator_class = class_double("DemoValidator", new: double("validator instance"))
-      logger = double("a logger")
-      expect(described_class.new([validator_class], logger)).to_not be_nil
-    end
-  end
-
-  describe "#run_validators_on" do
-    let(:sip)     { double("a sip") }
-    let(:logger)  { TestLogger.new }
-    let(:message) { double("a validator message", to_s: "uno\ndos") }
-    let(:validator_instance)  { double("a validator", validate: [message]) }
-    let(:validator_classes)   do
-      [class_double("ValidatorOne", new: validator_instance),
-       class_double("ValidatorTwo", new: validator_instance)]
-    end
-    let(:validator) { described_class.new(validator_classes, logger) }
-
-    it "runs each validators on the sip" do
-      validator_classes.each do |validator|
-        expect(validator).to receive(:new).with(sip)
-        expect(validator_instance).to receive(:validate)
-      end
-      validator.run_validators_on sip
-    end
-
-    it "logs the class names of each validator" do
-      validator.run_validators_on sip
-      validator_classes.each do |validator_class|
-        expect(logger.logs).to include(a_string_including(validator_class.to_s))
+    describe "#initialize" do
+      it "accepts an array of validator configurations and a logger" do
+        validator_config = ValidatorConfig.new("ValidatorOne")
+        logger = double("a logger")
+        expect(described_class.new([validator_config], logger)).to_not be_nil
       end
     end
 
-    it "logs the validator errors, adding indenting and preserving newlines" do
-      validator.run_validators_on sip
-      expect(logger.logs).to include("\tuno\n\tdos")
+    describe "#run_validators_on" do
+      include_context "with test logger"
+      let(:sip)     { double("a sip") }
+      let(:logger)  { TestLogger.new }
+      let(:config) do
+        [ValidatorConfig.new("ValidatorOne"),
+         ValidatorConfig.new("ValidatorTwo")]
+      end
+      let(:validator) { described_class.new(config, logger) }
+
+      shared_examples_for "a sipvalidator that runs each validator" do
+        it "runs each validator on the sip" do
+          config.each do |validator_config|
+            expect(validator_config.validator_class).to receive(:new).with(sip)
+            expect(validator_instance).to receive(:validate)
+          end
+          validator.run_validators_on sip
+        end
+      end
+
+      it_behaves_like "a sipvalidator that runs each validator"
+
+      it "logs the class names of each validator" do
+        validator.run_validators_on sip
+        config.each do |validator_config|
+          expect(logger.logs).to include(a_string_including(validator_config.validator_class.to_s))
+        end
+      end
+
+      it "logs the validator errors, adding indenting and preserving newlines" do
+        validator.run_validators_on sip
+        expect(logger.logs).to include("\tuno\n\tdos")
+      end
+
+      context "with a configuration listing dependencies" do
+        before(:each) do
+          class_double("HathiTrust::Validator::AlwaysError",
+            new: double("validator that always fails",
+              validate: [double("a failure message",
+                to_s: "it's an error",
+                error?: true)])).as_stubbed_const
+        end
+
+        context "when all validators succeed" do
+          it_behaves_like "a sipvalidator that runs each validator"
+        end
+
+        context "when a validator with a dependency fails" do
+          let(:error_config) do
+            [ValidatorConfig.new("AlwaysError"),
+             ValidatorConfig.new("ValidatorOne": "AlwaysError")]
+          end
+          let(:error_validator) { described_class.new(error_config, logger) }
+
+          it "does not run dependent validators" do
+            expect(Validator::ValidatorOne).not_to receive(:validate)
+
+            error_validator.run_validators_on(sip)
+          end
+
+          it "logs skipped validators with the failed dependency" do
+            error_validator.run_validators_on(sip)
+            expect(logger.logs).to include(
+              a_string_matching(/Skipping.*ValidatorOne.*AlwaysError.*failed/)
+            )
+          end
+        end
+
+        it "reports appropriately if dependency hasn't been run yet" do
+          error_config = [ValidatorConfig.new("ValidatorOne": "AlwaysError")]
+          error_validator = described_class.new(error_config, logger)
+
+          error_validator.run_validators_on(sip)
+          expect(logger.logs).to include(
+            a_string_matching(/Skipping.*ValidatorOne.*AlwaysError.*must be run before/)
+          )
+        end
+
+        it "reports if depdendency was skipped" do
+          error_config = [ValidatorConfig.new("AlwaysError"),
+                          ValidatorConfig.new("ValidatorOne": "AlwaysError"),
+                          ValidatorConfig.new("ValidatorTwo": "ValidatorOne")]
+          error_validator = described_class.new(error_config, logger)
+
+          error_validator.run_validators_on(sip)
+          expect(logger.logs).to include(
+            a_string_matching(/Skipping.*ValidatorTwo.*ValidatorOne.*skipped/)
+          )
+        end
+      end
     end
   end
 end

--- a/spec/validator_config_spec.rb
+++ b/spec/validator_config_spec.rb
@@ -7,15 +7,11 @@ module HathiTrust
     include_context "with stubbed validators"
 
     describe "#initialize" do
-      it "accepts a string" do
-        expect(ValidatorConfig.new("ValidatorOne")).to be_a(ValidatorConfig)
-      end
-      it "accepts a hash with one key whose value is a string" do
-        expect(ValidatorConfig.new("ValidatorOne": "ValidatorTwo"))
-          .to be_a(ValidatorConfig)
+      it "accepts an hash with one key whose value is an empty array" do
+        expect(ValidatorConfig.new("ValidatorOne": [])).to be_a(ValidatorConfig)
       end
       it "accepts a hash with one key whose value is an array of strings" do
-        expect(ValidatorConfig.new("ValidatorOne": "ValidatorThree"))
+        expect(ValidatorConfig.new("ValidatorOne": %w(ValidatorTwo ValidatorThree)))
           .to be_a(ValidatorConfig)
       end
 
@@ -37,7 +33,7 @@ module HathiTrust
         # don't use one of the stubbed validators
         # because a class double is not a class
         stub_const("HathiTrust::Validator::StubbedValidator", Class.new)
-        validator = ValidatorConfig.new("StubbedValidator")
+        validator = ValidatorConfig.new("StubbedValidator": [])
         expect(validator.validator_class).to be_a(Class)
       end
     end
@@ -45,14 +41,14 @@ module HathiTrust
     describe "#prerequisites" do
       context "with no prerequisites" do
         it "returns an empty array" do
-          validator = ValidatorConfig.new("ValidatorOne")
+          validator = ValidatorConfig.new("ValidatorOne": [])
           expect(validator.prerequisites).to eql([])
         end
       end
 
       context "with one prerequisite" do
         it "returns an array with one class" do
-          validator = ValidatorConfig.new("ValidatorOne": "ValidatorTwo")
+          validator = ValidatorConfig.new("ValidatorOne": ["ValidatorTwo"])
           expect(validator.prerequisites).to eql([HathiTrust::Validator::ValidatorTwo])
         end
       end

--- a/spec/validator_config_spec.rb
+++ b/spec/validator_config_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module HathiTrust
+
+  describe ValidatorConfig do
+    include_context "with stubbed validators"
+
+    describe "#initialize" do
+      it "accepts a string" do
+        expect(ValidatorConfig.new("ValidatorOne")).to be_a(ValidatorConfig)
+      end
+      it "accepts a hash with one key whose value is a string" do
+        expect(ValidatorConfig.new("ValidatorOne": "ValidatorTwo"))
+          .to be_a(ValidatorConfig)
+      end
+      it "accepts a hash with one key whose value is an array of strings" do
+        expect(ValidatorConfig.new("ValidatorOne": "ValidatorThree"))
+          .to be_a(ValidatorConfig)
+      end
+
+      it "does not accept a hash with multiple keys" do
+        expect do
+          ValidatorConfig.new("ValidatorOne": "ValidatorTwo",
+                              "ValidatorThree": "ValidatorTwo")
+        end.to raise_error(ArgumentError)
+      end
+
+      it "does not accept a hash with non-string values" do
+        expect { ValidatorConfig.new("ValidatorOne": { "ValidatorTwo": "ValidatorThree" }) }
+          .to raise_error(ArgumentError)
+      end
+    end
+
+    describe "#validator_class" do
+      it "returns a class" do
+        # don't use one of the stubbed validators
+        # because a class double is not a class
+        stub_const("HathiTrust::Validator::StubbedValidator", Class.new)
+        validator = ValidatorConfig.new("StubbedValidator")
+        expect(validator.validator_class).to be_a(Class)
+      end
+    end
+
+    describe "#prerequisites" do
+      context "with no prerequisites" do
+        it "returns an empty array" do
+          validator = ValidatorConfig.new("ValidatorOne")
+          expect(validator.prerequisites).to eql([])
+        end
+      end
+
+      context "with one prerequisite" do
+        it "returns an array with one class" do
+          validator = ValidatorConfig.new("ValidatorOne": "ValidatorTwo")
+          expect(validator.prerequisites).to eql([HathiTrust::Validator::ValidatorTwo])
+        end
+      end
+
+      context "with multiple prerequisites" do
+        it "returns an array with all the prerequisites" do
+          validator = ValidatorConfig.new("ValidatorOne": %w(ValidatorTwo ValidatorThree))
+          expect(validator.prerequisites).to eql([HathiTrust::Validator::ValidatorTwo,
+                                                  HathiTrust::Validator::ValidatorThree])
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
Closes #5 

- Allows specifying prerequisites for each validator to run
- Expectation is that the configuration will specify the prerequisite before any dependencies (that is, `SIPValidatorRunner` doesn't do any re-ordering/dependency resolution)
- Adds a `ValidatorConfig` class; this represents an element of a `Configuration` and encapsulates the validator's class and any prerequisites and has the logic to resolve those classes. (Could also use that later to indicate a validator's default severity/log level)