### PR TITLE
Feature/issue 38 - metayml dates

### DIFF
--- a/lib/ht_sip_validator/validator/message.rb
+++ b/lib/ht_sip_validator/validator/message.rb
@@ -43,6 +43,18 @@ module HathiTrust::Validator
       extras.key?(message) || super
     end
 
+    def ==(other)
+      if other.class == Array
+        binding.pry
+      end
+      error? == other.error? &&
+        validator == other.validator &&
+        validation_type == other.validation_type &&
+        human_message == other.human_message
+    end
+    alias_method :equal?, :==
+    alias_method :eql?, :==
+
     private
 
     attr_reader :level, :extras

--- a/lib/ht_sip_validator/validator/meta_yml.rb
+++ b/lib/ht_sip_validator/validator/meta_yml.rb
@@ -5,6 +5,7 @@ module HathiTrust::Validator::MetaYml
 end
 
 require "ht_sip_validator/validator/meta_yml/exists"
+require "ht_sip_validator/validator/meta_yml/date_format"
 require "ht_sip_validator/validator/meta_yml/required_keys"
 require "ht_sip_validator/validator/meta_yml/well_formed"
 require "ht_sip_validator/validator/meta_yml/unknown_keys"

--- a/lib/ht_sip_validator/validator/meta_yml/date_format.rb
+++ b/lib/ht_sip_validator/validator/meta_yml/date_format.rb
@@ -20,7 +20,7 @@ module HathiTrust::Validator
         rescue ArgumentError
           messages << create_error(
             validation_type: field.to_sym,
-            human_message: "An iso8601 combined date is required for #{field} in meta.yml.",
+            human_message: human_message(field),
             extras: {
               filename: "meta.yml",
               field: field,
@@ -30,6 +30,10 @@ module HathiTrust::Validator
         end
       end
       return messages
+    end
+
+    def human_message(field)
+      "An iso8601 combined date (e.g 2016-12-08T01:02:03-05:00) is required for #{field} in meta.yml."
     end
 
   end

--- a/lib/ht_sip_validator/validator/meta_yml/date_format.rb
+++ b/lib/ht_sip_validator/validator/meta_yml/date_format.rb
@@ -14,7 +14,9 @@ module HathiTrust::Validator
       messages = []
       FIELDS.each do |field|
         begin
-          DateTime.strptime(sip.metadata[field] || "", DATE_FORMAT)
+          unless sip.metadata[field].nil?
+            DateTime.strptime(sip.metadata[field], DATE_FORMAT)
+          end
         rescue ArgumentError
           messages << create_error(
             validation_type: field.to_sym,

--- a/lib/ht_sip_validator/validator/meta_yml/date_format.rb
+++ b/lib/ht_sip_validator/validator/meta_yml/date_format.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require "ht_sip_validator/validator/base"
+require "date"
+
+module HathiTrust::Validator
+  # Validates that package contains correctly formatted
+  # capture_date and image_compression_date
+
+  class MetaYml::DateFormat < Base
+    FIELDS = ["capture_date", "image_compression_date"].freeze
+    DATE_FORMAT = "%FT%T%:z".freeze
+
+    def perform_validation
+      messages = []
+      FIELDS.each do |field|
+        begin
+          DateTime.strptime(sip.metadata[field] || "", DATE_FORMAT)
+        rescue ArgumentError
+          messages << create_error(
+            validation_type: field.to_sym,
+            human_message: "An iso8601 combined date is required for #{field} in meta.yml.",
+            extras: {
+              filename: "meta.yml",
+              field: field,
+              actual: sip.metadata[field]
+            }
+          )
+        end
+      end
+      return messages
+    end
+
+  end
+end

--- a/spec/validator/meta_yml/date_format_spec.rb
+++ b/spec/validator/meta_yml/date_format_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+require "spec_helper"
+
+module HathiTrust
+
+  describe Validator::MetaYml::DateFormat do
+    let(:sip) do
+      double(:sip, metadata: {
+        "capture_date" => capture_date,
+        "image_compression_date" => image_compression_date
+      })
+    end
+    subject(:validator) { described_class.new(sip) }
+
+    let(:capture_date_error) do
+      Validator::Message.new(
+        validator: described_class,
+        validation_type: :capture_date,
+        level: :error,
+        human_message: "An iso8601 combined date is required for capture_date in meta.yml.",
+        extras: {
+          filename: "meta.yml",
+          field: "capture_date",
+          actual: capture_date
+        }
+      )
+    end
+
+    let(:image_compression_date_error) do
+      Validator::Message.new(
+        validator: described_class,
+        validation_type: :image_compression_date,
+        level: :error,
+        human_message: "An iso8601 combined date is required for image_compression_date in meta.yml.",
+        extras: {
+          filename: "meta.yml",
+          field: "image_compression_date",
+          actual: image_compression_date
+        }
+      )
+    end
+
+    context "when iso8601" do
+      let(:capture_date) { "2016-12-08T01:02:03-05:00" }
+      let(:image_compression_date) { "2000-02-29T12:12:59Z" }
+
+      it_behaves_like "a validator with the correct interface"
+      it_behaves_like "a validator with a valid package"
+      it_behaves_like "a validator that returns no messages"
+    end
+
+    context "when missing" do
+      let(:capture_date) { "2016-12-08T01:02:03-05:00" }
+      let(:image_compression_date) { nil }
+
+      it_behaves_like "a validator with an invalid package"
+
+      it "returns an appropriate message" do
+        # This test is more verbose than necessary due to a bug in rspec's collection matchers
+        messages = validator.validate
+        expect(messages.size).to eql(1)
+        expect(messages.first).to eql(image_compression_date_error)
+      end
+    end
+
+    context "when wrong format" do
+      let(:capture_date) { "2007-11-19 08:25:02 -0600" }
+      let(:image_compression_date) { "2010-03-30T05:43:25.1235000000Z" }
+
+      it_behaves_like "a validator with an invalid package"
+
+      it "returns two appropriate messages" do
+        messages = validator.validate
+        expect(messages.size).to eql(2)
+        expect(messages.first).to eql(capture_date_error)
+        expect(messages.last).to eql(image_compression_date_error)
+      end
+    end
+
+    context "when impossible date" do
+      let(:capture_date) { "2001-02-29T01:02:03-03:00" }
+      let(:image_compression_date) { "2002-02-29T12:12:59Z" }
+
+      it_behaves_like "a validator with an invalid package"
+
+      it "returns an appropriate message" do
+        messages = validator.validate
+        expect(messages.size).to eql(2)
+        expect(messages.first).to eql(capture_date_error)
+        expect(messages.last).to eql(image_compression_date_error)
+      end
+
+
+    end
+
+  end
+end

--- a/spec/validator/meta_yml/date_format_spec.rb
+++ b/spec/validator/meta_yml/date_format_spec.rb
@@ -17,7 +17,7 @@ module HathiTrust
         validator: described_class,
         validation_type: :capture_date,
         level: :error,
-        human_message: "An iso8601 combined date is required for capture_date in meta.yml.",
+        human_message: "An iso8601 combined date (e.g 2016-12-08T01:02:03-05:00) is required for capture_date in meta.yml.",
         extras: {
           filename: "meta.yml",
           field: "capture_date",
@@ -31,7 +31,7 @@ module HathiTrust
         validator: described_class,
         validation_type: :image_compression_date,
         level: :error,
-        human_message: "An iso8601 combined date is required for image_compression_date in meta.yml.",
+        human_message: "An iso8601 combined date (e.g 2016-12-08T01:02:03-05:00) is required for image_compression_date in meta.yml.",
         extras: {
           filename: "meta.yml",
           field: "image_compression_date",

--- a/spec/validator/meta_yml/date_format_spec.rb
+++ b/spec/validator/meta_yml/date_format_spec.rb
@@ -53,14 +53,10 @@ module HathiTrust
       let(:capture_date) { "2016-12-08T01:02:03-05:00" }
       let(:image_compression_date) { nil }
 
-      it_behaves_like "a validator with an invalid package"
+      it_behaves_like "a validator with the correct interface"
+      it_behaves_like "a validator with a valid package"
+      it_behaves_like "a validator that returns no messages"
 
-      it "returns an appropriate message" do
-        # This test is more verbose than necessary due to a bug in rspec's collection matchers
-        messages = validator.validate
-        expect(messages.size).to eql(1)
-        expect(messages.first).to eql(image_compression_date_error)
-      end
     end
 
     context "when wrong format" do


### PR DESCRIPTION
Resolves #38 

* 130d5cb - This commit adds equality methods to Validator::Message, to enable more clarity in rspec matchers.  
* 1d31645 - This contains resolves #38, using the strategies that have been established by other validators.
* d429b45 - This introduces the idea of a data file that contains the specification for error messages, in config/messages.yml.  It adds a convenience method to the specs to use the yaml file, and uses said method for the MetaYml::DateFormat validator.  I'm hoping to gain stability in the way messages are formatted, as they are part of the API.  This also represents a single source of truth.

  If this is something we find we want, we can begin to use it at our leisure.  This commit does _not_ contain an easy implementation for the non-spec code to use, so that would be the next step.

  Otherwise, this PR is ready without d429b45.