### PR TITLE
Fix/issue 100

### DIFF
--- a/lib/ht_sip_validator/sip_validator_runner.rb
+++ b/lib/ht_sip_validator/sip_validator_runner.rb
@@ -57,7 +57,7 @@ class HathiTrust::SIPValidatorRunner
 
     errors = validator_class.new(sip).validate_file(filename, FIXME)
     results[validator_class] = validator_success?(errors)
-    errors.each {|error| @logger.info "\t" + error.to_s.gsub("\n", "\n\t") }
+    errors.each {|error| @logger.public_send(really_just_the_message_error_level(error), "\t" + error.to_s.gsub("\n", "\n\t"))}
   end
 
   def run_validator_on(validator_class, sip, results)
@@ -65,7 +65,7 @@ class HathiTrust::SIPValidatorRunner
 
     errors = validator_class.new(sip).validate
     results[validator_class] = validator_success?(errors)
-    errors.each {|error| @logger.info "\t" + error.to_s.gsub("\n", "\n\t") }
+    errors.each {|error| @logger.public_send(really_just_the_message_error_level(error), "\t" + error.to_s.gsub("\n", "\n\t"))}
   end
 
   def skip_validator(validator_config, results)
@@ -86,6 +86,12 @@ class HathiTrust::SIPValidatorRunner
     else
       :info
     end
+  end
+
+  def really_just_the_message_error_level(message)
+    return :error if message.error?
+    return :warn if message.warning?
+    return :info
   end
 
   def prereq_failure_message(result)

--- a/spec/support/contexts/with_stubbed_validators.rb
+++ b/spec/support/contexts/with_stubbed_validators.rb
@@ -2,7 +2,13 @@
 require "spec_helper"
 
 shared_context "with stubbed validators" do
-  let(:message) { double("a validator message", to_s: "uno\ndos", error?: false) }
+  let(:message) do
+    double("a validator message",
+      to_s: "uno\ndos",
+      error?: false,
+      warning?: false
+    )
+  end
   let(:validator_instance)  { double("a validator", validate: [message]) }
 
   before(:each) do


### PR DESCRIPTION
* Log error and warning at their level.
* For reference, we continue to log skipped validators as INFO, even if their pre-req failed, so as to not mislead the packager.

This PR does not include tests!  sip_validator_runner needs a refactoring pass anyway as it is quite complex.  An issue will be created for the tests.