### PR TITLE
tests for sip validator with doubled filevalidators

### DIFF
--- a/spec/support/contexts/with_stubbed_validators.rb
+++ b/spec/support/contexts/with_stubbed_validators.rb
@@ -6,15 +6,22 @@ shared_context "with stubbed validators" do
     double("a validator message",
       to_s: "uno\ndos",
       error?: false,
-      warning?: false
-    )
+      warning?: false)
   end
-  let(:validator_instance)  { double("a validator", validate: [message]) }
+  let(:validator_instance) { double("a validator", validate: [message]) }
+  let(:file_validator_instance) { double("a file validator", validate_file: [message]) }
 
   before(:each) do
     %w(ValidatorOne ValidatorTwo ValidatorThree).each do |validator|
       class_double("HathiTrust::Validator::#{validator}",
         new: validator_instance).as_stubbed_const
+    end
+  end
+
+  before(:each) do
+    %w(FileValidatorOne FileValidatorTwo).each do |validator|
+      class_double("HathiTrust::Validator::#{validator}",
+        new: file_validator_instance).as_stubbed_const
     end
   end
 end

--- a/spec/validator/sip_validator_spec.rb
+++ b/spec/validator/sip_validator_spec.rb
@@ -21,19 +21,41 @@ module HathiTrust
         [ValidatorConfig.new("ValidatorOne": []),
          ValidatorConfig.new("ValidatorTwo": [])]
       end
+      let(:file_checks) do
+        [ValidatorConfig.new("FileValidatorOne": []),
+         ValidatorConfig.new("FileValidatorTwo": [])]
+      end
       let(:mocked_config) { Configuration.new(StringIO.new("")) }
       let(:validator) { described_class.new(mocked_config, logger) }
       before(:each) do
         allow(mocked_config).to receive(:package_checks).and_return(package_checks)
-        allow(sip).to receive(:files).and_return([])
-        allow(sip).to receive(:each_file).and_return(nil)
+        allow(mocked_config).to receive(:file_checks).and_return(file_checks)
+
+        mocked_files = %w(00000001.txt 00000001.tif 00000001.xml 00000002.txt
+                          00000002.jp2 00000002.xml)
+
+        allow(sip).to receive(:files).and_return(mocked_files)
+
+        # make each_file yield each filename in turn
+        mocked_files.map {|name| [name, StringIO.new("")] }
+          .reduce(allow(sip).to(receive(:each_file))) {|a, e| a.and_yield(*e) }
       end
 
       shared_examples_for "a sipvalidator that runs each validator" do
-        it "runs each validator on the sip" do
+        it "runs each package validator on the sip" do
           package_checks.each do |validator_config|
             expect(validator_config.validator_class).to receive(:new).with(sip)
             expect(validator_instance).to receive(:validate)
+          end
+          validator.run_validators_on sip
+        end
+
+        it "runs each file validator on each file in the sip" do
+          sip.files.each do |_file|
+            file_checks.each do |validator_config|
+              expect(validator_config.validator_class).to receive(:new).with(sip)
+              expect(file_validator_instance).to receive(:validate_file)
+            end
           end
           validator.run_validators_on sip
         end
@@ -67,13 +89,17 @@ module HathiTrust
         end
 
         context "when a validator with a dependency fails" do
-          let(:error_checks) do
+          let(:error_package_checks) do
             [ValidatorConfig.new("AlwaysError": []),
              ValidatorConfig.new("ValidatorOne": ["AlwaysError"])]
           end
+          let(:error_file_checks) do
+            [ ValidatorConfig.new("FileValidatorOne": ["AlwaysError"])]
+          end
           let(:error_config) { Configuration.new(StringIO.new("")) }
           let(:error_validator) { described_class.new(error_config, logger) }
-          before(:each) { allow(error_config).to receive(:package_checks).and_return(error_checks) }
+          before(:each) { allow(error_config).to receive(:package_checks).and_return(error_package_checks) }
+          before(:each) { allow(error_config).to receive(:file_checks).and_return(error_file_checks) }
 
           it "does not run dependent validators" do
             expect(Validator::ValidatorOne).not_to receive(:validate)
@@ -81,10 +107,21 @@ module HathiTrust
             error_validator.run_validators_on(sip)
           end
 
+          it "does not run dependent file validators" do
+            expect(Validator::FileValidatorOne).not_to receive(:validate_file)
+
+            error_validator.run_validators_on(sip)
+          end
+
           it "logs skipped validators with the failed dependency" do
             error_validator.run_validators_on(sip)
+            # \b for word boundary - ensure there's actually a message for validators
+            # we care about - since ValidatorOne is a substring of FileValidatorOne
             expect(logger.logs).to include(
-              a_string_matching(/Skipping.*ValidatorOne.*AlwaysError.*failed/)
+              a_string_matching(/Skipping.*\bValidatorOne\b.*\bAlwaysError\b.*failed/)
+            )
+            expect(logger.logs).to include(
+              a_string_matching(/Skipping.*\bFileValidatorOne\b.*\bAlwaysError\b.*failed/)
             )
           end
         end


### PR DESCRIPTION
The doubles are maybe a bit verbose and hard to reason about, and this could certainly stand to be DRYed up a bit, but I think between this and the integration tests from #114 this should sufficiently cover the needs.